### PR TITLE
job profile collection fixes and masking pat

### DIFF
--- a/cmd/local/apicollect/jobprofiles.go
+++ b/cmd/local/apicollect/jobprofiles.go
@@ -47,22 +47,22 @@ func getNumberOfJobProfilesCollected(c *conf.CollectConf) (tried, collected int,
 	queriesrows := queriesjson.CollectQueriesJSON(queriesjsons)
 	profilesToCollect := map[string]string{}
 
+	simplelog.Infof("searching queries.json for %v of jobProfilesNumSlowPlanning", c.JobProfilesNumSlowPlanning())
 	slowplanqueriesrows := queriesjson.GetSlowPlanningJobs(queriesrows, c.JobProfilesNumSlowPlanning())
 	queriesjson.AddRowsToSet(slowplanqueriesrows, profilesToCollect)
 
+	simplelog.Infof("searching queries.json for %v of jobProfilesNumSlowExec", c.JobProfilesNumSlowExec())
 	slowexecqueriesrows := queriesjson.GetSlowExecJobs(queriesrows, c.JobProfilesNumSlowExec())
 	queriesjson.AddRowsToSet(slowexecqueriesrows, profilesToCollect)
 
+	simplelog.Infof("searching queries.json for profiles %v of jobProfilesNumHighQueryCost", c.JobProfilesNumHighQueryCost())
 	highcostqueriesrows := queriesjson.GetHighCostJobs(queriesrows, c.JobProfilesNumHighQueryCost())
 	queriesjson.AddRowsToSet(highcostqueriesrows, profilesToCollect)
 
+	simplelog.Infof("searching queries.json for %v of jobProfilesNumRecentErrors", c.JobProfilesNumRecentErrors())
 	errorqueriesrows := queriesjson.GetRecentErrorJobs(queriesrows, c.JobProfilesNumRecentErrors())
 	queriesjson.AddRowsToSet(errorqueriesrows, profilesToCollect)
 
-	simplelog.Infof("jobProfilesNumSlowPlanning: %v", c.JobProfilesNumSlowPlanning())
-	simplelog.Infof("jobProfilesNumSlowExec: %v", c.JobProfilesNumSlowExec())
-	simplelog.Infof("jobProfilesNumHighQueryCost: %v", c.JobProfilesNumHighQueryCost())
-	simplelog.Infof("jobProfilesNumRecentErrors: %v", c.JobProfilesNumRecentErrors())
 	tried = len(profilesToCollect)
 	if len(profilesToCollect) > 0 {
 		simplelog.Infof("Downloading %v job profiles...", len(profilesToCollect))

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -142,6 +142,14 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 
 	supportedExtensions := []string{"yaml", "json", "toml", "hcl", "env", "props"}
 	foundConfig := ParseConfig(configDir, viper.SupportedExts, overrides)
+	simplelog.Info("logging parsed configuration from ddc.yaml")
+	for k, v := range viper.AllSettings() {
+		if k == KeyDremioPatToken && v != "" {
+			simplelog.Infof("conf key '%v':'REDACTED'", k)
+		} else {
+			simplelog.Infof("conf key '%v':'%v'", k, v)
+		}
+	}
 	// now we can setup verbosity as we are parsing it in the ParseConfig function
 	verboseString := viper.GetString("verbose")
 	verbose := strings.Count(verboseString, "v")
@@ -258,8 +266,6 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 	c.jobProfilesNumSlowExec = jobProfilesNumSlowExec
 	c.jobProfilesNumRecentErrors = jobProfilesNumRecentErrors
 	c.jobProfilesNumSlowPlanning = jobProfilesNumSlowPlanning
-
-	simplelog.Infof("Current configuration: %+v", viper.AllSettings())
 
 	return c, nil
 }

--- a/cmd/local/conf/conf_test.go
+++ b/cmd/local/conf/conf_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
+	"github.com/dremio/dremio-diagnostic-collector/cmd/simplelog"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/tests"
 )
 
 var _ = Describe("Conf", func() {
@@ -117,6 +119,21 @@ collect-kvstore-report: true
 			Expect(cfg.CollectSystemTablesExport()).To(BeTrue())
 			Expect(cfg.CollectWLM()).To(BeTrue())
 			Expect(cfg.DremioConfDir()).To(Equal("/path/to/dremio/conf"))
+		})
+	})
+
+	Context("when logging parsing of ddc.yaml ", func() {
+		It("should log redacted when token is present", func() {
+			out, err := tests.CaptureOutput(func() {
+				simplelog.InitLogger(4)
+				cfg, err = conf.ReadConf(overrides, tmpDir)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+			})
+			if err != nil {
+				simplelog.Errorf("unable to capture output %v", err)
+			}
+			Expect(out).To(ContainSubstring("conf key 'dremio-pat-token':'REDACTED'"))
 		})
 	})
 })

--- a/cmd/local/conf/job_profile_calculations.go
+++ b/cmd/local/conf/job_profile_calculations.go
@@ -20,10 +20,6 @@ import (
 )
 
 func calculateDefaultJobProfileNumbers(c *CollectConf) (defaultJobProfilesNumSlowExec, defaultJobProfilesNumRecentErrors, defaultJobProfilesNumSlowPlanning, defaultJobProfilesNumHighQueryCost int) {
-	// don't bother doing any of the calculation if personal access token is not present in fact zero out everything
-	if c.DremioPATToken() == "" {
-		return
-	}
 	// check if job profile is set
 	if c.NumberJobProfilesToCollect() > 0 {
 		if c.NumberJobProfilesToCollect() < 4 {

--- a/cmd/local/queriesjson/queries.go
+++ b/cmd/local/queriesjson/queries.go
@@ -234,12 +234,11 @@ func min(a, b int) int {
 	return b
 }
 
-func AddRowsToSet(queriesrows []QueriesRow, profilesToCollect map[string]string) map[string]string {
+func AddRowsToSet(queriesrows []QueriesRow, profilesToCollect map[string]string) {
 	for _, row := range queriesrows {
 		jobid := row.QueryID
 		profilesToCollect[jobid] = ""
 	}
-	return profilesToCollect
 }
 
 func CollectQueriesJSON(queriesjsons []string) []QueriesRow {

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -138,7 +138,7 @@ func Execute(c Collector, s CopyStrategy, collectionArgs Args, clusterCollection
 				NodeCaptureOutput: "/tmp/ddc", //TODO use node output dirs from the config
 			}
 			//we want to be able to capture the job profiles of all the nodes
-			skipRESTCalls := true
+			skipRESTCalls := false
 			writtenFiles, failedFiles, skippedFiles := Capture(coordinatorCaptureConf, ddcLoc, ddcYamlFilePath, s.GetTmpDir(), skipRESTCalls)
 			m.Lock()
 			totalFailedFiles = append(totalFailedFiles, failedFiles...)
@@ -163,7 +163,9 @@ func Execute(c Collector, s CopyStrategy, collectionArgs Args, clusterCollection
 				DDCfs:             ddcfs,
 				NodeCaptureOutput: "/tmp/ddc",
 			}
-			writtenFiles, failedFiles, skippedFiles := Capture(executorCaptureConf, ddcLoc, ddcYamlFilePath, s.GetTmpDir(), true)
+			//always skip executor calls
+			skipRESTCalls := true
+			writtenFiles, failedFiles, skippedFiles := Capture(executorCaptureConf, ddcLoc, ddcYamlFilePath, s.GetTmpDir(), skipRESTCalls)
 			m.Lock()
 			totalFailedFiles = append(totalFailedFiles, failedFiles...)
 			totalSkippedFiles = append(totalSkippedFiles, skippedFiles...)

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -10,7 +10,7 @@ dremio-endpoint: "http://localhost:9047" # dremio endpoint on each node to use f
 dremio-username: "dremio" # dremio user to for collecting Workload Manager, KV Report and Job Profiles 
 dremio-pat-token: "" # when set will attempt to collect Workload Manager, KV report and Job Profiles. Dremio PATs can be enabled by the support key auth.personal-access-tokens.enabled
 collect-dremio-configuration: true # will collect dremio.conf, dremio-env, logback.xml and logback-access.xml
-number-job-profiles: 25000 # need to have the dremio-pat-token set to work
+number-job-profiles: 25000 # up to this number, may have less due to duplicates NOTE: need to have the dremio-pat-token set to work
 capture-heap-dump: false # when true a heap dump will be captured on each node that the collector is run against
 accept-collection-consent: true # when true you accept consent to collect data on each node, if false collection will fail
 allow-insecure-ssl: true # when true skip the ssl cert check when doing API calls


### PR DESCRIPTION
* coordinator pods were not collecting REST calls ever
* job profile calculation had extra uncessary test for pat check
* updated commentary in ddc.yaml for job profiles to explain it is "up
  to" instead of "it will be" this number of job profiles
* we were needlessly returning a map in Add queriesjson.AddRowsToSet
* dremio PAT is no longer logged in the logs and it is now REDACTED when
  present, however an empty PAT is logged for debugging purposes
