### PR TITLE
Executors were not running capture on ssh

### DIFF
--- a/cmd/local/apicollect/jobprofiles.go
+++ b/cmd/local/apicollect/jobprofiles.go
@@ -47,26 +47,26 @@ func GetNumberOfJobProfilesCollected(c *conf.CollectConf) (tried, collected int,
 	queriesrows := queriesjson.CollectQueriesJSON(queriesjsons)
 	profilesToCollect := map[string]string{}
 
-	simplelog.Infof("searching queries.json for %v of jobProfilesNumSlowPlanning", c.JobProfilesNumSlowPlanning())
+	simplelog.Debugf("searching queries.json for %v of jobProfilesNumSlowPlanning", c.JobProfilesNumSlowPlanning())
 	slowplanqueriesrows := queriesjson.GetSlowPlanningJobs(queriesrows, c.JobProfilesNumSlowPlanning())
 	queriesjson.AddRowsToSet(slowplanqueriesrows, profilesToCollect)
 
-	simplelog.Infof("searching queries.json for %v of jobProfilesNumSlowExec", c.JobProfilesNumSlowExec())
+	simplelog.Debugf("searching queries.json for %v of jobProfilesNumSlowExec", c.JobProfilesNumSlowExec())
 	slowexecqueriesrows := queriesjson.GetSlowExecJobs(queriesrows, c.JobProfilesNumSlowExec())
 	queriesjson.AddRowsToSet(slowexecqueriesrows, profilesToCollect)
 
-	simplelog.Infof("searching queries.json for profiles %v of jobProfilesNumHighQueryCost", c.JobProfilesNumHighQueryCost())
+	simplelog.Debugf("searching queries.json for profiles %v of jobProfilesNumHighQueryCost", c.JobProfilesNumHighQueryCost())
 	highcostqueriesrows := queriesjson.GetHighCostJobs(queriesrows, c.JobProfilesNumHighQueryCost())
 	queriesjson.AddRowsToSet(highcostqueriesrows, profilesToCollect)
 
-	simplelog.Infof("searching queries.json for %v of jobProfilesNumRecentErrors", c.JobProfilesNumRecentErrors())
+	simplelog.Debugf("searching queries.json for %v of jobProfilesNumRecentErrors", c.JobProfilesNumRecentErrors())
 	errorqueriesrows := queriesjson.GetRecentErrorJobs(queriesrows, c.JobProfilesNumRecentErrors())
 	queriesjson.AddRowsToSet(errorqueriesrows, profilesToCollect)
 
 	tried = len(profilesToCollect)
 	if len(profilesToCollect) > 0 {
-		simplelog.Infof("Downloading %v job profiles...", len(profilesToCollect))
-		downloadThreadPool := threading.NewThreadPoolWithJobQueue(c.NumberThreads(), len(profilesToCollect))
+		simplelog.Debugf("Downloading %v job profiles...", len(profilesToCollect))
+		downloadThreadPool := threading.NewThreadPoolWithJobQueue(c.NumberThreads(), len(profilesToCollect), 100)
 		for key := range profilesToCollect {
 			//because we are looping
 			keyToDownload := key
@@ -98,7 +98,7 @@ func RunCollectJobProfiles(c *conf.CollectConf) error {
 	if err != nil {
 		return err
 	}
-	simplelog.Infof("After eliminating duplicates we are tried to collect %v profiles", tried)
+	simplelog.Debugf("After eliminating duplicates we are tried to collect %v profiles", tried)
 	simplelog.Infof("Downloaded %v job profiles", collected)
 	return nil
 }

--- a/cmd/local/apicollect/kvreports.go
+++ b/cmd/local/apicollect/kvreports.go
@@ -51,6 +51,6 @@ func RunCollectKvReport(c *conf.CollectConf) error {
 	if err != nil {
 		return fmt.Errorf("unable to create file %s due to error %v", filename, err)
 	}
-	simplelog.Info("SUCCESS - Created " + filename)
+	simplelog.Debugf("SUCCESS - Created " + filename)
 	return nil
 }

--- a/cmd/local/apicollect/system_tables.go
+++ b/cmd/local/apicollect/system_tables.go
@@ -32,7 +32,7 @@ import (
 )
 
 func RunCollectDremioSystemTables(c *conf.CollectConf) error {
-	simplelog.Info("Collecting results from Export System Tables...")
+	simplelog.Debugf("Collecting results from Export System Tables...")
 	err := ValidateAPICredentials(c)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func RunCollectDremioSystemTables(c *conf.CollectConf) error {
 		if err != nil {
 			return fmt.Errorf("unable to create file %s due to error %v", filename, err)
 		}
-		simplelog.Info("SUCCESS - Created " + filename)
+		simplelog.Debugf("SUCCESS - Created " + filename)
 	}
 
 	return nil
@@ -101,7 +101,7 @@ func downloadSysTable(c *conf.CollectConf, systable string, rowlimit int, sleepm
 	}
 	if jobstate == "COMPLETED" {
 		jobresultsurl := c.DremioEndpoint() + "/apiv2/job/" + jobid + "/data?offset=0&limit=" + strconv.Itoa(rowlimit)
-		simplelog.Info("Retrieving job results ...")
+		simplelog.Debugf("Retrieving job results ...")
 		body, err := restclient.APIRequest(jobresultsurl, c.DremioPATToken(), "GET", headers)
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve job results from %s due to error %v", jobresultsurl, err)

--- a/cmd/local/apicollect/validate.go
+++ b/cmd/local/apicollect/validate.go
@@ -22,7 +22,7 @@ import (
 )
 
 func ValidateAPICredentials(c *conf.CollectConf) error {
-	simplelog.Info("Validating REST API user credentials...")
+	simplelog.Debugf("Validating REST API user credentials...")
 	url := c.DremioEndpoint() + "/apiv2/login"
 	headers := map[string]string{"Content-Type": "application/json"}
 	_, err := restclient.APIRequest(url, c.DremioPATToken(), "GET", headers)

--- a/cmd/local/apicollect/wlm.go
+++ b/cmd/local/apicollect/wlm.go
@@ -90,7 +90,7 @@ func RunCollectWLM(c *conf.CollectConf) error {
 		}
 
 		// Log a success message upon successful creation of the file
-		simplelog.Infof("SUCCESS - Created " + filename)
+		simplelog.Debugf("SUCCESS - Created " + filename)
 	}
 
 	// Return nil if the entire operation completes successfully

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -142,12 +142,12 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 
 	supportedExtensions := []string{"yaml", "json", "toml", "hcl", "env", "props"}
 	foundConfig := ParseConfig(configDir, viper.SupportedExts, overrides)
-	simplelog.Info("logging parsed configuration from ddc.yaml")
+	simplelog.Debugf("logging parsed configuration from ddc.yaml")
 	for k, v := range viper.AllSettings() {
 		if k == KeyDremioPatToken && v != "" {
-			simplelog.Infof("conf key '%v':'REDACTED'", k)
+			simplelog.Debugf("conf key '%v':'REDACTED'", k)
 		} else {
-			simplelog.Infof("conf key '%v':'%v'", k, v)
+			simplelog.Debugf("conf key '%v':'%v'", k, v)
 		}
 	}
 	// now we can setup verbosity as we are parsing it in the ParseConfig function
@@ -167,7 +167,7 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 	if foundConfig == "" {
 		simplelog.Warningf("was unable to read any of the valid config file formats (%v) due to error '%v' - falling back to defaults, command line flags and environment variables", strings.Join(supportedExtensions, ","), c.unableToReadConfigError)
 	} else {
-		simplelog.Infof("found config file %v", foundConfig)
+		simplelog.Debugf("found config file %v", foundConfig)
 	}
 	c.acceptCollectionConsent = viper.GetBool(KeyAcceptCollectionConsent)
 	c.collectAccelerationLogs = viper.GetBool(KeyCollectAccelerationLog)
@@ -189,14 +189,14 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 			} else {
 				// ok so looks like we need to adjust this since the node name is not already in the path
 				c.dremioLogDir = path.Join(c.dremioLogDir, "executor", c.nodeName)
-				simplelog.Infof("AWSE detected adding the node name %v to the log directory path %v", c.nodeName, c.dremioLogDir)
+				simplelog.Debugf("AWSE detected adding the node name %v to the log directory path %v", c.nodeName, c.dremioLogDir)
 			}
 		} else {
 			if strings.Contains(c.dremioLogDir, "coordinator") {
 				simplelog.Warningf("coordinator already included in log directory of %v make this is intentional as you do not need to put the coordinator in the log path", c.dremioLogDir)
 			} else {
 				c.dremioLogDir = path.Join(c.dremioLogDir, "coordinator")
-				simplelog.Infof("AWSE coordinator node detected adding coordinator name to log dir %v", c.dremioLogDir)
+				simplelog.Debugf("AWSE coordinator node detected adding coordinator name to log dir %v", c.dremioLogDir)
 			}
 		}
 	}
@@ -234,7 +234,7 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 	}
 	if parsedGCLogDir != "" {
 		if c.gcLogsDir == "" {
-			simplelog.Infof("setting gc logs to %v", parsedGCLogDir)
+			simplelog.Debugf("setting gc logs to %v", parsedGCLogDir)
 		} else {
 			simplelog.Warningf("overriding gc logs location from %v to %v due to detection of gclog directory", c.gcLogsDir, parsedGCLogDir)
 		}
@@ -250,9 +250,11 @@ func ReadConf(overrides map[string]*pflag.Flag, configDir string) (*CollectConf,
 	c.dremioJStackFreqSeconds = viper.GetInt(KeyDremioJStackFreqSeconds)
 
 	// collect rest apis
-	personalAccessTokenPresent := c.dremioPATToken != ""
+	personalAccessTokenPresent := c.DremioPATToken() != ""
 	if !personalAccessTokenPresent {
 		simplelog.Warningf("disabling all Workload Manager, System Table, KV Store, and Job Profile collection since the --dremio-pat-token is not set")
+	} else {
+		simplelog.Errorf("--dremio-pat-token is set to %q", c.DremioPATToken())
 	}
 	c.allowInsecureSSL = viper.GetBool(KeyAllowInsecureSSL)
 	c.collectWLM = viper.GetBool(KeyCollectWLM) && personalAccessTokenPresent

--- a/cmd/local/conf/parse_config.go
+++ b/cmd/local/conf/parse_config.go
@@ -35,7 +35,7 @@ func ParseConfig(configDir string, supportedExtensions []string, overrides map[s
 		confFiles = append(confFiles, fmt.Sprintf("%v.%v", baseConfig, e))
 	}
 
-	simplelog.Infof("searching in directory %v for the following: %v", configDir, strings.Join(confFiles, ", "))
+	simplelog.Debugf("searching in directory %v for the following: %v", configDir, strings.Join(confFiles, ", "))
 	//searching for all known
 	for _, ext := range supportedExtensions {
 		viper.SetConfigType(ext)
@@ -49,7 +49,12 @@ func ParseConfig(configDir string, supportedExtensions []string, overrides map[s
 	viper.AutomaticEnv() // Automatically read environment variables
 
 	for k, v := range overrides {
-		viper.Set(k, v)
+		//this really only applies for running over ssh so why am I doing it here? because we end up doing some crazy stuff as a result!
+		if v.Value.String() == "\"\"" {
+			viper.Set(k, "")
+		} else {
+			viper.Set(k, v.Value.String())
+		}
 	}
 	return
 }

--- a/cmd/local/logcollect/logcollect.go
+++ b/cmd/local/logcollect/logcollect.go
@@ -51,12 +51,12 @@ func NewLogCollector(dremioLogDir, logsOutDir, gcLogsDir, dremioGCFilePattern, q
 }
 
 func (l *Collector) RunCollectDremioServerLog() error {
-	simplelog.Info("Collecting GC logs ...")
+	simplelog.Debug("Collecting GC logs ...")
 	var errs []error
 	if err := l.exportArchivedLogs(l.dremioLogDir, "server.log", "server", l.dremioLogsNumDays); err != nil {
 		errs = append(errs, fmt.Errorf("trying to archive server logs we got error: %v", err))
 	}
-	simplelog.Info("... collecting server.out")
+	simplelog.Debug("... collecting server.out")
 	src := path.Join(l.dremioLogDir, "server.out")
 	dest := path.Join(l.logsOutDir, "server.out")
 	if err := ddcio.CopyFile(path.Clean(src), path.Clean(dest)); err != nil {
@@ -67,7 +67,7 @@ func (l *Collector) RunCollectDremioServerLog() error {
 	} else if (len(errs)) == 1 {
 		return errs[0]
 	}
-	simplelog.Info("... collecting server logs COMPLETED")
+	simplelog.Debug("... collecting server logs COMPLETED")
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (l *Collector) RunCollectGcLogs() error {
 	if l.gcLogsDir == "" {
 		simplelog.Warningf("Skipping GC Logs no gc log directory is configured set dremio-gclogs-dir in ddc.yaml")
 	} else {
-		simplelog.Info("Collecting GC logs ...")
+		simplelog.Debug("Collecting GC logs ...")
 	}
 	files, err := os.ReadDir(path.Clean(l.gcLogsDir))
 	if err != nil {
@@ -116,64 +116,58 @@ func (l *Collector) RunCollectGcLogs() error {
 	} else if (len(errs)) == 1 {
 		return errs[0]
 	}
-	simplelog.Warning("GC logs from executors and scale-out coordinators must be collected separately!")
-	simplelog.Info("... collecting GC logs COMPLETED")
+	simplelog.Debug("... collecting GC logs COMPLETED")
 
 	return nil
 }
 
 func (l *Collector) RunCollectMetadataRefreshLogs() error {
-	simplelog.Info("Collecting metadata refresh logs from Coordinator(s) ...")
+	simplelog.Debug("Collecting metadata refresh logs from Coordinator(s) ...")
 	if err := l.exportArchivedLogs(l.dremioLogDir, "metadata_refresh.log", "metadata_refresh", l.dremioLogsNumDays); err != nil {
 		return fmt.Errorf("unable to collect metadata refresh logs due to error %v", err)
 	}
-	simplelog.Warning("Metadata refresh logs from scale-out coordinators must be collected separately!")
-	simplelog.Info("... collecting meta data refresh logs from Coordinator(s) COMPLETED")
+	simplelog.Debug("... collecting meta data refresh logs from Coordinator(s) COMPLETED")
 	return nil
 }
 
 func (l *Collector) RunCollectReflectionLogs() error {
-	simplelog.Info("Collecting reflection logs from Coordinator(s) ...")
+	simplelog.Debug("Collecting reflection logs from Coordinator(s) ...")
 	if err := l.exportArchivedLogs(l.dremioLogDir, "reflection.log", "reflection", l.dremioLogsNumDays); err != nil {
 		return fmt.Errorf("unable to collect reflection logs due to error %v", err)
 	}
-	simplelog.Info("... collecting reflection logs from Coordinator(s) COMPLETED")
+	simplelog.Debug("... collecting reflection logs from Coordinator(s) COMPLETED")
 
 	return nil
 }
 
 func (l *Collector) RunCollectDremioAccessLogs() error {
-	simplelog.Info("Collecting access logs from Coordinator(s) ...")
-	simplelog.Warning("Access logs from scale-out coordinators must be collected separately!")
+	simplelog.Debug("Collecting access logs from Coordinator(s) ...")
 	if err := l.exportArchivedLogs(l.dremioLogDir, "access.log", "access", l.dremioLogsNumDays); err != nil {
 		return fmt.Errorf("unable to archive access.logs due to error %v", err)
 	}
-	simplelog.Info("... collecting access logs from Coordinator(s) COMPLETED")
+	simplelog.Debug("... collecting access logs from Coordinator(s) COMPLETED")
 
 	return nil
 }
 
 func (l *Collector) RunCollectAccelerationLogs() error {
-	simplelog.Info("Collecting acceleration logs from Coordinator(s) ...")
-	simplelog.Warning("Acceleration logs from scale-out coordinators must be collected separately!")
+	simplelog.Debug("Collecting acceleration logs from Coordinator(s) ...")
 	if err := l.exportArchivedLogs(l.dremioLogDir, "acceleration.log", "acceleration", l.dremioLogsNumDays); err != nil {
 		return fmt.Errorf("unable to archive acceleration.logs due to error %v", err)
 	}
-	simplelog.Info("... collecting acceleragtion logs from Coordinator(s) COMPLETED")
+	simplelog.Debug("... collecting acceleragtion logs from Coordinator(s) COMPLETED")
 
 	return nil
 }
 
 func (l *Collector) RunCollectQueriesJSON() error {
-	simplelog.Info("Collecting queries.json ...")
+	simplelog.Debug("Collecting queries.json ...")
 	err := l.exportArchivedLogs(l.dremioLogDir, "queries.json", "queries", l.dremioQueriesJSONNumDays)
 	if err != nil {
 		return fmt.Errorf("failed to export archived logs: %v", err)
 	}
 
-	simplelog.Warning("Queries.json from scale-out coordinators must be collected separately!")
-
-	simplelog.Info("... collecting Queries JSON for Job Profiles COMPLETED")
+	simplelog.Debug("... collecting Queries JSON for Job Profiles COMPLETED")
 	return nil
 }
 
@@ -203,7 +197,7 @@ func (l *Collector) exportArchivedLogs(srcLogDir string, unarchivedFile string, 
 		//now search files for a match
 		for _, f := range files {
 			if strings.HasPrefix(f.Name(), fmt.Sprintf("%v.%v", logPrefix, processingDate)) {
-				simplelog.Info("Copying archive file for " + processingDate + ": " + f.Name())
+				simplelog.Debugf("Copying archive file for %v:%v", processingDate, f.Name())
 				src := filepath.Join(srcLogDir, "archive", f.Name())
 				dst := filepath.Join(outDir, f.Name())
 				if strings.HasSuffix(f.Name(), ".gz") {

--- a/cmd/local/queriesjson/queries.go
+++ b/cmd/local/queriesjson/queries.go
@@ -245,7 +245,7 @@ func CollectQueriesJSON(queriesjsons []string) []QueriesRow {
 
 	queriesrows := []QueriesRow{}
 	for _, queriesjson := range queriesjsons {
-		simplelog.Infof("Attempting to open queries.json file %v", queriesjson)
+		simplelog.Debugf("Attempting to open queries.json file %v", queriesjson)
 		rows := []QueriesRow{}
 		var err error
 
@@ -268,7 +268,7 @@ func CollectQueriesJSON(queriesjsons []string) []QueriesRow {
 		}
 		log.Println("Found", strconv.Itoa(len(rows)), "new rows in", queriesjson)
 	}
-	simplelog.Infof("Collected a total of %v rows of queries.json", len(queriesrows))
+	simplelog.Debugf("Collected a total of %v rows of queries.json", len(queriesrows))
 	return queriesrows
 }
 

--- a/cmd/local/threading/thread_test.go
+++ b/cmd/local/threading/thread_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 var setupThreadPool = func() {
-	tp = threading.NewThreadPool(10)
+	tp = threading.NewThreadPool(10, 1)
 }
 
 func TestThreadPool_WhenWaitWithOneJob(t *testing.T) {

--- a/cmd/root/cli/cli.go
+++ b/cmd/root/cli/cli.go
@@ -64,7 +64,7 @@ type Cli struct {
 // be returned as an error from this function.
 func (c *Cli) ExecuteAndStreamOutput(outputHandler OutputHandler, args ...string) error {
 	// Log the command that's about to be run
-	simplelog.Infof("args: %v\n", strings.Join(args, " "))
+	simplelog.Debugf("args: %v\n", strings.Join(args, " "))
 
 	// Create the command based on the passed arguments
 	cmd := exec.Command(args[0], args[1:]...)
@@ -134,7 +134,7 @@ func (c *Cli) ExecuteAndStreamOutput(outputHandler OutputHandler, args ...string
 }
 
 func (c *Cli) Execute(args ...string) (string, error) {
-	simplelog.Infof("args: %v", strings.Join(args, " "))
+	simplelog.Debugf("args: %v", strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = os.Stderr
 	output, err := cmd.Output()
@@ -145,7 +145,7 @@ func (c *Cli) Execute(args ...string) (string, error) {
 }
 
 func (c *Cli) ExecuteBytes(args ...string) ([]byte, error) {
-	simplelog.Infof("args: %v", strings.Join(args, " "))
+	simplelog.Debugf("args: %v", strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = os.Stderr
 	output, err := cmd.Output()

--- a/cmd/root/collection/capture.go
+++ b/cmd/root/collection/capture.go
@@ -82,12 +82,12 @@ func Capture(conf HostCaptureConfiguration, localDDCPath, localDDCYamlPath, outp
 			Err:  fmt.Errorf("unable to copy local ddc yaml to remote path due to error: '%v' with output '%v'", err, out),
 		})
 	} else {
-		simplelog.Infof("successfully copied ddc.yaml to host %v", host)
+		simplelog.Debugf("successfully copied ddc.yaml to host %v", host)
 	}
 	//execute local-collect if skipRESTCollect is set blank the pat
 	localCollectArgs := []string{pathToDDC, "local-collect"}
 	if skipRESTCollect {
-		localCollectArgs = append(localCollectArgs, "--dremio-pat-token", "")
+		localCollectArgs = append(localCollectArgs, "--dremio-pat-token", "\"\"")
 	}
 	if err := ComposeExecuteAndStream(conf, func(line string) {
 		simplelog.HostLog(host, line)
@@ -96,14 +96,14 @@ func Capture(conf HostCaptureConfiguration, localDDCPath, localDDCYamlPath, outp
 		simplelog.Warningf("on host %v capture failed due to error '%v'", host, err)
 		//return
 	} else {
-		simplelog.Infof("on host %v capture successful", host)
+		simplelog.Debugf("on host %v capture successful", host)
 	}
 	//defer delete tar.gz
 	defer func() {
 		if out, err := ComposeExecute(conf, []string{"rm", "-fr", path.Join(ddcTmpDir)}); err != nil {
 			simplelog.Warningf("on host %v unable to cleanup remote capture due to error '%v' with output '%v'", host, err, out)
 		} else {
-			simplelog.Infof("on host %v tarballs in directory %v have been removed", host, ddcTmpDir)
+			simplelog.Debugf("on host %v tarballs in directory %v have been removed", host, ddcTmpDir)
 		}
 	}()
 
@@ -120,7 +120,7 @@ func Capture(conf HostCaptureConfiguration, localDDCPath, localDDCYamlPath, outp
 		for _, sourceFile := range foundTarGzFiles {
 			//have to use filepath for cross platform path on client
 			destFile := filepath.Join(outDir, filepath.Base(sourceFile))
-			simplelog.Infof("found %v for copying to %v", sourceFile, destFile)
+			simplelog.Debugf("found %v for copying to %v", sourceFile, destFile)
 			//but we want to use path.join here because otherwise it will be wrong for linux servers
 			//note also we do not care about sudo when copying back the archive
 			if out, err := ComposeCopyNoSudo(conf, path.Join(ddcTmpDir, sourceFile), destFile); err != nil {

--- a/cmd/root/collection/collector.go
+++ b/cmd/root/collection/collector.go
@@ -206,17 +206,17 @@ func Execute(c Collector, s CopyStrategy, collectionArgs Args, clusterCollection
 		return err
 	}
 	if len(tarballs) > 0 {
-		simplelog.Infof("extracting the following tarballs %v", strings.Join(tarballs, ", "))
+		simplelog.Debugf("extracting the following tarballs %v", strings.Join(tarballs, ", "))
 		for _, t := range tarballs {
-			simplelog.Infof("extracting %v to %v", t, s.GetTmpDir())
+			simplelog.Debugf("extracting %v to %v", t, s.GetTmpDir())
 			if err := ExtractTarGz(t, s.GetTmpDir()); err != nil {
 				simplelog.Errorf("unable to extract tarball %v due to error %v", t, err)
 			}
-			simplelog.Infof("extracted %v", t)
+			simplelog.Debugf("extracted %v", t)
 			if err := os.Remove(t); err != nil {
 				simplelog.Errorf("unable to delete tarball %v due to error %v", t, err)
 			}
-			simplelog.Infof("removed %v", t)
+			simplelog.Debugf("removed %v", t)
 		}
 	}
 	// archives the collected files
@@ -294,7 +294,7 @@ func ExtractTarGz(gzFilePath, dest string) error {
 }
 
 func FindTarGzFiles(rootDir string) ([]string, error) {
-	simplelog.Infof("looking in %v for tar.gz files", rootDir)
+	simplelog.Debugf("looking in %v for tar.gz files", rootDir)
 	var files []string
 	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	//initial logger before verbosity is parsed
-	simplelog.InitLogger(3)
+	simplelog.InitLogger(2)
 	defer func() {
 		if err := simplelog.Close(); err != nil {
 			log.Printf("unable to close log due to error %v", err)

--- a/pkg/masking/config_mask.go
+++ b/pkg/masking/config_mask.go
@@ -76,7 +76,7 @@ func maskConfigSecret(line string) string {
 func RemoveSecretsFromDremioConf(configFile string) error {
 	// Check if the input file is a Dremio configuration file
 	if strings.HasSuffix(configFile, "dremio.conf") {
-		simplelog.Infof("... Removing potential secrets from %s\n", configFile)
+		simplelog.Debugf("... Removing potential secrets from %s\n", configFile)
 
 		// Open the file. Clean the configFile path before opening to remove any relative or redundant path elements.
 		// If there is an issue opening the file, an error is returned.

--- a/pkg/simplelog/logger.go
+++ b/pkg/simplelog/logger.go
@@ -58,7 +58,12 @@ func InitLogger(level int) {
 }
 
 func Close() error {
-	logger.Info("Close called on log")
+	logger.Debug("Close called on log")
+	logger.debugLogger = log.New(io.Discard, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile)
+	logger.infoLogger = log.New(io.Discard, "INFO:  ", log.Ldate|log.Ltime|log.Lshortfile)
+	logger.warningLogger = log.New(io.Discard, "WARN:  ", log.Ldate|log.Ltime|log.Lshortfile)
+	logger.errorLogger = log.New(io.Discard, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	logger.hostLog = log.New(io.Discard, "", 0)
 	if err := ddcLog.Close(); err != nil {
 		return fmt.Errorf("unable to close ddc.log with error %v", err)
 	}
@@ -76,7 +81,10 @@ func newLogger(level int) *Logger {
 		adjustedLevel = 3
 	}
 
-	debugOut, infoOut, warningOut, errorOut := io.Discard, io.Discard, io.Discard, io.Discard
+	var debugOut io.Writer
+	var infoOut io.Writer
+	var warningOut io.Writer
+	var errorOut io.Writer
 	ddcLoc, err := os.Executable()
 	if err != nil {
 		log.Fatalf("unable to to find ddc cannot copy it to hosts due to error '%v'", err)
@@ -107,6 +115,7 @@ func newLogger(level int) *Logger {
 	}
 	internalDebug(adjustedLevel, fmt.Sprintf("initialized log with level %v", stringLevelText))
 
+	debugOut, infoOut, warningOut, errorOut = ddcLog, ddcLog, ddcLog, ddcLog
 	//set logger levels because we rely on fall through we cannot use the above switch easily
 	switch adjustedLevel {
 	case LevelDebug:


### PR DESCRIPTION
* We have normalized interpretation of the --dremio-pat-token parameter
  when passed to executors across ssh and kubernetes, both interpret a
  blank argument differently ssh views `--dremio-pat-token ` as no
  argument for --dremio-pat-token and kubernetes exec views that as an
  empty argument. Likewise if one provides `--dremio-pat-token ""` ssh
  will see that as en empty argument and kubernetes will escape the
  quotes sending "\"\"" as the argument for --dremio-pat-token. This has
  all been normalized and the values "" and "\"\"" are considered
  equivalent when parsing command line args in local-collect
* Reduced console logging considerable and default verbosity level, each
  nodes ddc.log however is still maximum verbosity
* logging was not cleaning dropping older configuration, now it does
* lowered default logging for the cli
* progress is now marked by task progression in the thread pool, this
  has the advantage of still showing progress, but not too much
