### PR TITLE
123 unexpected use of tmp path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,11 +91,12 @@ func RemoteCollect(collectionArgs collection.Args, sshArgs ssh.Args, kubeArgs ku
 		}
 		return fmt.Errorf("invalid command flag detected: %w", err)
 	}
-	cs := helpers.NewHCCopyStrategy(collectionArgs.DDCfs, &helpers.RealTimeService{})
 	// This is where the SSH or K8s collection is determined. We create an instance of the interface based on this
 	// which then determines whether the commands are routed to the SSH or K8s commands
-
-	//default no op
+	cs, err := helpers.NewHCCopyStrategy(collectionArgs.DDCfs, &helpers.RealTimeService{})
+	if err != nil {
+		return fmt.Errorf("error when creating copy strategy: %v", err)
+	}
 	var clusterCollect = func([]string) {}
 	var collectorStrategy collection.Collector
 	if k8sEnabled {

--- a/cmd/root/helpers/fshelper.go
+++ b/cmd/root/helpers/fshelper.go
@@ -20,6 +20,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 )
 
 // fshelper provides functions to wrapper os file system calls
@@ -113,8 +115,18 @@ func (f RealFileSystem) Mkdir(name string, perms os.FileMode) error {
 }
 
 // MkdirTemp
-func (f RealFileSystem) MkdirTemp(name string, pattern string) (string, error) {
+/*func (f RealFileSystem) MkdirTemp(name string, pattern string) (string, error) {
 	dir, err := os.MkdirTemp(name, pattern)
+	return dir, err
+}
+*/
+
+func (f RealFileSystem) MkdirTemp(name string, pattern string) (dir string, err error) {
+	if conf.KeyTmpOutputDir == "" {
+		dir, err = os.MkdirTemp(name, pattern)
+	} else {
+		dir = conf.KeyTmpOutputDir
+	}
 	return dir, err
 }
 

--- a/cmd/root/helpers/fshelper.go
+++ b/cmd/root/helpers/fshelper.go
@@ -115,12 +115,6 @@ func (f RealFileSystem) Mkdir(name string, perms os.FileMode) error {
 }
 
 // MkdirTemp
-/*func (f RealFileSystem) MkdirTemp(name string, pattern string) (string, error) {
-	dir, err := os.MkdirTemp(name, pattern)
-	return dir, err
-}
-*/
-
 func (f RealFileSystem) MkdirTemp(name string, pattern string) (dir string, err error) {
 	if conf.KeyTmpOutputDir == "" {
 		dir, err = os.MkdirTemp(name, pattern)

--- a/cmd/root/helpers/healthcheck_strategy.go
+++ b/cmd/root/helpers/healthcheck_strategy.go
@@ -37,17 +37,17 @@ func (r *RealTimeService) GetNow() time.Time {
 	return time.Now()
 }
 
-func NewHCCopyStrategy(ddcfs Filesystem, timeService TimeService) *CopyStrategyHC {
+func NewHCCopyStrategy(ddcfs Filesystem, timeService TimeService) (*CopyStrategyHC, error) {
 	now := timeService.GetNow()
 	dir := now.Format("20060102-150405-DDC")
-	tmpDir, _ := ddcfs.MkdirTemp("", "*")
+	tmpDir, err := ddcfs.MkdirTemp("", "*")
 	return &CopyStrategyHC{
 		StrategyName: "healthcheck",
 		BaseDir:      dir,
 		TmpDir:       tmpDir,
 		Fs:           ddcfs,
 		TimeService:  timeService,
-	}
+	}, err
 }
 
 /*

--- a/cmd/root/helpers/healthcheck_strategy_test.go
+++ b/cmd/root/helpers/healthcheck_strategy_test.go
@@ -36,7 +36,10 @@ func TestBaseDirHC(t *testing.T) {
 	timeService := MockTimeService{
 		Time: now,
 	}
-	testStrat := NewHCCopyStrategy(ddcfs, &timeService)
+	testStrat, err := NewHCCopyStrategy(ddcfs, &timeService)
+	if err != nil {
+		t.Errorf("error when creating copy strategy: %v", err)
+	}
 	expected := now.Format("20060102-150405-DDC")
 	actual := testStrat.BaseDir
 	// Check the base dir is set on creation
@@ -48,9 +51,12 @@ func TestBaseDirHC(t *testing.T) {
 // Tests the constructor is setting a temp dir
 func TestTmpDirHC(t *testing.T) {
 	ddcfs := NewFakeFileSystem()
-	testStrat := NewHCCopyStrategy(ddcfs, &MockTimeService{
+	testStrat, err := NewHCCopyStrategy(ddcfs, &MockTimeService{
 		Time: time.Now(),
 	})
+	if err != nil {
+		t.Errorf("error when creating copy strategy: %v", err)
+	}
 	expected := filepath.Join("tmp", "dir1", "random")
 	actual := testStrat.TmpDir
 	// Check the base dir is set on creation
@@ -62,7 +68,10 @@ func TestTmpDirHC(t *testing.T) {
 // Tests the method returns the correct path
 func TestGetPathHC(t *testing.T) {
 	ddcfs := NewFakeFileSystem()
-	testStrat := NewHCCopyStrategy(ddcfs, &MockTimeService{Time: time.Now()})
+	testStrat, err := NewHCCopyStrategy(ddcfs, &MockTimeService{Time: time.Now()})
+	if err != nil {
+		t.Errorf("error when creating copy strategy: %v", err)
+	}
 	// Test path for coordinators
 	expected := filepath.Join("tmp", "dir1", "random", testStrat.BaseDir, "log", "node1-C")
 	actual, _ := testStrat.CreatePath("log", "node1", "coordinator")
@@ -81,7 +90,10 @@ func TestGetPathHC(t *testing.T) {
 // it tests the call via the selected strategy
 func TestArchiveDiagHC(t *testing.T) {
 	ddcfs := NewRealFileSystem()
-	testStrat := NewHCCopyStrategy(ddcfs, &MockTimeService{Time: time.Now()})
+	testStrat, err := NewHCCopyStrategy(ddcfs, &MockTimeService{Time: time.Now()})
+	if err != nil {
+		t.Errorf("error when creating copy strategy: %v", err)
+	}
 	tmpDir := t.TempDir()
 	testFileRaw := filepath.Join("testdata", "test.txt")
 	if testFile, err := filepath.Abs(testFileRaw); err != nil {


### PR DESCRIPTION
Ensures we use the configured tmp path before defaulting to the OS tmpdir. Add missing error check 