### PR TITLE
165 include kubectl describe node as text output in ddc

### DIFF
--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -265,6 +265,7 @@ func findClusterID(c *conf.CollectConf) (string, error) {
 	startTime := time.Now().Unix()
 	var clusterID string
 	rocksDBDir := c.DremioRocksDBDir()
+	simplelog.Debugf("checking dir %v for cluster version", rocksDBDir)
 	err := filepath.Walk(rocksDBDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("prevent panic by handling failure accessing a path %q: %v", path, err)
@@ -276,6 +277,7 @@ func findClusterID(c *conf.CollectConf) (string, error) {
 		if !info.IsDir() {
 			// readonly cannot modify the files touched
 			f, err := os.Open(filepath.Clean(path))
+			simplelog.Debugf("checking file %v for cluster version", f.Name())
 			if err != nil {
 				return fmt.Errorf("error reading file %s: %v", path, err)
 			}
@@ -370,7 +372,7 @@ func parseVersionFromClassPath(classPath string) string {
 
 func getClassPath(pid int) (string, error) {
 	var w bytes.Buffer
-	if err := ddcio.Shell(&w, fmt.Sprintf("jcmd %v system_properties", pid)); err != nil {
+	if err := ddcio.Shell(&w, fmt.Sprintf("jcmd %v VM.system_properties", pid)); err != nil {
 		return "", err
 	}
 	out := w.String()
@@ -392,10 +394,12 @@ func getClassPath(pid int) (string, error) {
 func runCollectClusterStats(c *conf.CollectConf) error {
 	simplelog.Debugf("Collecting cluster stats")
 	classPath, err := getClassPath(c.DremioPID())
+	simplelog.Debugf("classpath %v", classPath)
 	if err != nil {
 		return err
 	}
 	dremioVersion := parseVersionFromClassPath(classPath)
+	simplelog.Debugf("dremio version %v", dremioVersion)
 	clusterID, err := findClusterID(c)
 	if err != nil {
 		return err

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -394,7 +394,6 @@ func getClassPath(pid int) (string, error) {
 func runCollectClusterStats(c *conf.CollectConf) error {
 	simplelog.Debugf("Collecting cluster stats")
 	classPath, err := getClassPath(c.DremioPID())
-	simplelog.Debugf("classpath %v", classPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,6 +153,10 @@ func RemoteCollect(collectionArgs collection.Args, sshArgs ssh.Args, kubeArgs ku
 			if err != nil {
 				simplelog.Errorf("when getting container logs, the following error was returned: %v", err)
 			}
+			err = collection.GetClusterNodes(kubeArgs.Namespace, cs, collectionArgs.DDCfs, kubeArgs.KubectlPath)
+			if err != nil {
+				simplelog.Errorf("when getting cluster nodes, the following error was returned: %v", err)
+			}
 		}
 	} else {
 		simplelog.Info("using SSH based collection")

--- a/cmd/root/helpers/healthcheck_strategy.go
+++ b/cmd/root/helpers/healthcheck_strategy.go
@@ -97,9 +97,14 @@ func (s *CopyStrategyHC) CreatePath(fileType, source, nodeType string) (path str
 	baseDir := s.BaseDir
 	tmpDir := s.TmpDir
 
-	// We only tag a suffix of '-C' / '-E' for ssh nodes, the K8s pods are desriptive enough to determine the coordinator / executpr
+	// We only tag a suffix of '-C' / '-E' for ssh nodes, the K8s pods are desriptive enough to determine the coordinator / executor
+	// also add exceptions for general k8s directories
 	var isK8s bool
-	if strings.Contains(source, "dremio-master") || strings.Contains(source, "dremio-executor") || strings.Contains(source, "dremio-coordinator") || strings.Contains(source, "container-logs") {
+	if strings.Contains(source, "dremio-master") ||
+		strings.Contains(source, "dremio-executor") ||
+		strings.Contains(source, "dremio-coordinator") ||
+		strings.Contains(source, "container-logs") ||
+		strings.Contains(source, "nodes") {
 		isK8s = true
 	}
 	if !isK8s { // SSH node types

--- a/integrationtest/kube/collect_kube_test.go
+++ b/integrationtest/kube/collect_kube_test.go
@@ -585,6 +585,11 @@ dremio-jfr-time-seconds: 10
 	t.Logf("checking file %v", filepath.Join(hcDir, "node-info", "dremio-executor-0", "os_info.txt"))
 	tests.AssertFileHasExpectedLines(t, []string{">>> mount", ">>> lsblk"}, filepath.Join(hcDir, "node-info", "dremio-executor-0", "os_info.txt"))
 
+	// check cluster describe node files
+	tests.AssertFileHasContent(t, filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
+	t.Logf("checking file %v", filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
+	tests.AssertFileHasExpectedLines(t, []string{"Name:", "Role:", "Label:"}, filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
+
 	//kvstore report
 	tests.AssertFileHasContent(t, filepath.Join(hcDir, "kvstore", "dremio-master-0", "kvstore-report.zip"))
 


### PR DESCRIPTION
Two commits here: 
- fixes an issue where we send incorrect jcmd syntax and we only got an exit code 1
- adds collection of kubectl describe nodes