### PR TITLE
Fix failing test

### DIFF
--- a/integrationtest/kube/collect_kube_test.go
+++ b/integrationtest/kube/collect_kube_test.go
@@ -588,7 +588,7 @@ dremio-jfr-time-seconds: 10
 	// check cluster describe node files
 	tests.AssertFileHasContent(t, filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
 	t.Logf("checking file %v", filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
-	tests.AssertFileHasExpectedLines(t, []string{"Name:", "Role:", "Label:"}, filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
+	tests.AssertFileHasExpectedLines(t, []string{"Name:", "Roles:", "Labels:"}, filepath.Join(hcDir, "kubernetes", "nodes", "describe-nodes.txt"))
 
 	//kvstore report
 	tests.AssertFileHasContent(t, filepath.Join(hcDir, "kvstore", "dremio-master-0", "kvstore-report.zip"))

--- a/pkg/tests/file.go
+++ b/pkg/tests/file.go
@@ -16,7 +16,6 @@ package tests
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +55,6 @@ func MatchLines(expectedLines []string, actualFile string) (bool, error) {
 	}
 
 	// We take each expected line and check for matches
-	matches := 0
 	mi := 0
 	for _, expectedLine := range expectedLines {
 		matchLine.word = expectedLine
@@ -64,7 +62,6 @@ func MatchLines(expectedLines []string, actualFile string) (bool, error) {
 		matchLines = append(matchLines, matchLine)
 		for _, actualLine := range actualLines {
 			if strings.Contains(actualLine, expectedLine) {
-				matches = matches + 1
 				matchLines[mi].word = expectedLine
 				matchLines[mi].matched = true
 			}
@@ -74,7 +71,6 @@ func MatchLines(expectedLines []string, actualFile string) (bool, error) {
 	// We have to see at least one match on each expected line
 	// if not then the whole check fails
 	for _, m := range matchLines {
-		fmt.Println(m)
 		if !m.matched {
 			return false, nil
 		}

--- a/pkg/tests/file_test.go
+++ b/pkg/tests/file_test.go
@@ -50,7 +50,7 @@ func TestFileContents(t *testing.T) {
 
 	var match bool
 	// Expect testFile to contain the expected lines
-	match, err := tests.MatchLines(expectedText, testFile)
+	match, err := tests.MatchLines(t, expectedText, testFile)
 	if !match {
 		t.Errorf("expected %v to contain %v", testFile, expectedText)
 	}


### PR DESCRIPTION
The test was failing because we were counting up the matches and if we had multiple matches of one thing then the count would be > expected. While this is ok, we need to make sure we have one match on each string and not 10 on one and none on the other so it needed a bit more thought