### PR TITLE
tmp-output-dir now defaults to tarball-out-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Updated list of available system tables for Software and Cloud
 * ddc command no longer uses random output directory in /tmp for copy destination, but instead uses the directory for the tarball output
 * ttop no longer outputs to the temp folder
+* ddc.yaml tmp-output-dir now defaults to using tarball-out-dir as it's base directory
+* tmp-output-dir is now deprecated as it was too hard to configure correctly
 
 ### Fixed
 * fixed not actually allowing the DREMIO_LOG_DIR to be used 

--- a/cmd/local/conf/defaults.go
+++ b/cmd/local/conf/defaults.go
@@ -22,7 +22,7 @@ func setDefault(confData map[string]interface{}, key string, value interface{}) 
 }
 
 // SetViperDefaults wires up default values for viper when the ddc.yaml or the cli flags do not set the value
-func SetViperDefaults(confData map[string]interface{}, hostName string, defaultCaptureSeconds int, outputDir string) {
+func SetViperDefaults(confData map[string]interface{}, hostName string, defaultCaptureSeconds int) {
 	// set default config
 	setDefault(confData, KeyVerbose, "vv")
 	setDefault(confData, KeyDisableRESTAPI, false)
@@ -43,7 +43,6 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 	setDefault(confData, KeyNumberJobProfiles, 25000)
 	setDefault(confData, KeyDremioEndpoint, "http://localhost:9047")
 	setDefault(confData, KeyTarballOutDir, "/tmp/ddc")
-	setDefault(confData, KeyTmpOutputDir, outputDir)
 	setDefault(confData, KeyCollectOSConfig, true)
 	setDefault(confData, KeyCollectDiskUsage, true)
 	setDefault(confData, KeyDremioLogsNumDays, 7)

--- a/cmd/local/conf/defaults_test.go
+++ b/cmd/local/conf/defaults_test.go
@@ -22,19 +22,18 @@ import (
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 )
 
-func setupTestSetViperDefaults() (map[string]interface{}, string, int, string) {
+func setupTestSetViperDefaults() (map[string]interface{}, string, int) {
 	hostName := "test-host"
 	defaultCaptureSeconds := 30
-	outputDir := "/tmp"
 	confData := make(map[string]interface{})
 	// Run the function.
-	conf.SetViperDefaults(confData, hostName, defaultCaptureSeconds, outputDir)
+	conf.SetViperDefaults(confData, hostName, defaultCaptureSeconds)
 
-	return confData, hostName, defaultCaptureSeconds, outputDir
+	return confData, hostName, defaultCaptureSeconds
 }
 
 func TestSetViperDefaults(t *testing.T) {
-	confData, hostName, defaultCaptureSeconds, outputDir := setupTestSetViperDefaults()
+	confData, hostName, defaultCaptureSeconds := setupTestSetViperDefaults()
 
 	checks := []struct {
 		key      string
@@ -58,7 +57,6 @@ func TestSetViperDefaults(t *testing.T) {
 		{conf.KeyNumberJobProfiles, 25000},
 		{conf.KeyDremioEndpoint, "http://localhost:9047"},
 		{conf.KeyTarballOutDir, "/tmp/ddc"},
-		{conf.KeyTmpOutputDir, outputDir},
 		{conf.KeyCollectOSConfig, true},
 		{conf.KeyCollectDiskUsage, true},
 		{conf.KeyDremioLogsNumDays, 7},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -213,7 +213,7 @@ func ValidateAndReadYaml(ddcYaml string) (map[string]interface{}, error) {
 	}
 
 	// set defaults so we get an accurate reading of if these will be enabled or not
-	conf.SetViperDefaults(confData, "", 0, "")
+	conf.SetViperDefaults(confData, "", 0)
 	return confData, nil
 }
 

--- a/cmd/root/collection/capture.go
+++ b/cmd/root/collection/capture.go
@@ -124,7 +124,7 @@ func Capture(conf HostCaptureConfiguration, localDDCPath, localDDCYamlPath, outp
 	}, localCollectArgs)
 	if err != nil {
 
-		status := "FAILED - LOCAL-COLLECT - " + strutils.LimitString(strings.Join(allHostLog, " - "), 350)
+		status := "FAILED - LOCAL-COLLECT - " + strutils.LimitString(strings.Join(allHostLog, " - "), 1024)
 		consoleprint.UpdateNodeState(host, status)
 		return 0, "", fmt.Errorf("on host %v capture failed due to error '%v' output was %v", host, err, strings.Join(allHostLog, "\n"))
 	}


### PR DESCRIPTION
main thing this provides is largely making tmp-output-dir obsolete and I've set the stage for it to be deprecated and removed. This will make later documentation much easier to understand and this will now become easier to avoid the tmp folder just by setting one parameter