### PR TITLE
avoiding use of tmp for transfer of ddc binary and yaml

### DIFF
--- a/cmd/root/collection/collector.go
+++ b/cmd/root/collection/collector.go
@@ -90,6 +90,7 @@ func Execute(c Collector, s CopyStrategy, collectionArgs Args, clusterCollection
 	coordinatorStr := collectionArgs.CoordinatorStr
 	executorsStr := collectionArgs.ExecutorsStr
 	outputLoc := collectionArgs.OutputLoc
+	outputLocDir := filepath.Dir(outputLoc)
 	sudoUser := collectionArgs.SudoUser
 	ddcfs := collectionArgs.DDCfs
 	dremioPAT := collectionArgs.DremioPAT
@@ -97,16 +98,17 @@ func Execute(c Collector, s CopyStrategy, collectionArgs Args, clusterCollection
 	ddcYamlFilePath := collectionArgs.DDCYamlLoc
 	var ddcLoc string
 	var err error
-	tmpIinstallDir, err := os.MkdirTemp("", "ddcex-output")
+	tmpInstallDir := filepath.Join(outputLocDir, fmt.Sprintf("ddcex-output-%v", time.Now().Unix()))
+	err = os.Mkdir(tmpInstallDir, 0700)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if err := os.RemoveAll(tmpIinstallDir); err != nil {
+		if err := os.RemoveAll(tmpInstallDir); err != nil {
 			simplelog.Warningf("unable to cleanup temp install directory: '%v'", err)
 		}
 	}()
-	ddcLoc, err = ddcbinary.WriteOutDDC(tmpIinstallDir)
+	ddcLoc, err = ddcbinary.WriteOutDDC(tmpInstallDir)
 	if err != nil {
 		return fmt.Errorf("making ddc binary failed: '%v'", err)
 	}


### PR DESCRIPTION
This is part of the temp fix and fits in with the pattern we are using where the tarball output folder is where we have decided to start doing file work in ddc. While this is suboptimal from a folder content perspective and makes the intermediary status of folder creation visible to the end user it does mean cleanup is more trivial and obvious, if not as automatic as when we use the temp folder
