### PR TITLE
Move validation

### DIFF
--- a/cmd/local/apicollect/jobprofiles_test.go
+++ b/cmd/local/apicollect/jobprofiles_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/apicollect"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 )
 
 func TestGetNumberOfJobProfilesCollectedWIthServerUp(t *testing.T) {
@@ -87,7 +88,7 @@ dremio-endpoint: %v
 	if err != nil {
 		t.Fatalf("missing conf file %v", err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatalf("unable to read conf %v", err)
 	}

--- a/cmd/local/apicollect/wlm_test.go
+++ b/cmd/local/apicollect/wlm_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/apicollect"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 )
 
 func setupConfigDir(t *testing.T, endpoint string) (confDir string) {
@@ -93,7 +94,7 @@ func TestRunCollectWLM(t *testing.T) {
 	ddcYaml := filepath.Join(confDir, "ddc.yaml")
 	// Prepare the configuration
 	overrides := make(map[string]string)
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatalf("unable to read conf due to error %v", err)
 	}

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/restclient"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/dirs"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/simplelog"
-	"github.com/dremio/dremio-diagnostic-collector/pkg/validation"
 	"github.com/google/uuid"
 	"github.com/spf13/cast"
 )
@@ -200,7 +199,7 @@ func LogConfData(confData map[string]string) {
 		}
 	}
 }
-func ReadConf(overrides map[string]string, ddcYamlLoc string) (*CollectConf, error) {
+func ReadConf(overrides map[string]string, ddcYamlLoc, collectionMode string) (*CollectConf, error) {
 	confData, err := ParseConfig(ddcYamlLoc, overrides)
 	if err != nil {
 		return &CollectConf{}, fmt.Errorf("config failed: %w", err)
@@ -211,10 +210,6 @@ func ReadConf(overrides map[string]string, ddcYamlLoc string) (*CollectConf, err
 	hostName, err := os.Hostname()
 	if err != nil {
 		hostName = fmt.Sprintf("unknown-%v", uuid.New())
-	}
-	collectionMode := GetString(confData, KeyCollectionMode)
-	if err := validation.ValidateCollectMode(collectionMode); err != nil {
-		return &CollectConf{}, err
 	}
 
 	SetViperDefaults(confData, hostName, defaultCaptureSeconds, collectionMode)

--- a/cmd/local/conf/conf_test.go
+++ b/cmd/local/conf/conf_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/simplelog"
 )
 
@@ -132,7 +133,7 @@ dremio-cloud-project-id: "224653935291683895642623390599291234"
 dremio-endpoint: eu.dremio.cloud
 `)
 	//should parse the configuration correctly
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -188,7 +189,7 @@ func TestConfCanUseTarballOutputDirWithAllowedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(cfgFilePath)
-	_, err = conf.ReadConf(overrides, cfgFilePath)
+	_, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Errorf("should not have error: %v", err)
 	}
@@ -218,7 +219,7 @@ func TestConfCannotUseTarballOutputDirWithFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(cfgFilePath)
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err == nil {
 		t.Error("should have an error")
 	}
@@ -235,7 +236,7 @@ dremio-cloud-project-id: "224653935291683895642623390599291234"
 dremio-endpoint: dremio.cloud
 `)
 	//should parse the configuration correctly
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -264,7 +265,7 @@ dremio-endpoint: dremio.cloud
 func TestConfReadingWithAValidConfigurationFile(t *testing.T) {
 	genericConfSetup("")
 	//should parse the configuration correctly
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		b, yamlErr := os.ReadFile(cfgFilePath)
 		if yamlErr != nil {
@@ -376,7 +377,7 @@ collect-kvstore-report: true
 `, filepath.Join("testdata", "logs"), filepath.Join("testdata", "conf"))
 	genericConfSetup(yaml)
 	defer afterEachConfTest()
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -414,7 +415,7 @@ func TestConfReadingWhenLoggingParsingOfDdcYAML(t *testing.T) {
 	testLog := filepath.Join(t.TempDir(), "ddc.log")
 	simplelog.InitLoggerWithFile(4, testLog)
 	//should log redacted when token is present
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Fatalf("expected no error but had %v", err)
 	}
@@ -456,7 +457,7 @@ func TestURLsuffix(t *testing.T) {
 
 func TestClusterStatsDirectory(t *testing.T) {
 	genericConfSetup("")
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -497,7 +498,7 @@ dremio-conf-dir: %v
 	genericConfSetup(yaml)
 
 	// we expect an error since "badlogs" doesnt have the right files
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if cfg == nil {
 		t.Error("expected a valid CollectConf but it is nil")
 	}
@@ -512,7 +513,7 @@ dremio-conf-dir: %v
 	genericConfSetup("")
 
 	// we don't expect an error since "logs" has the right files
-	cfg, err = conf.ReadConf(overrides, cfgFilePath)
+	cfg, err = conf.ReadConf(overrides, cfgFilePath, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/local/configcollect/dremio_conf_test.go
+++ b/cmd/local/configcollect/dremio_conf_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/configcollect"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/tests"
 	"github.com/rogpeppe/go-internal/diff"
 )
@@ -56,7 +57,7 @@ node-name: %v
 		t.Fatal(err)
 	}
 	overrides := make(map[string]string)
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +151,7 @@ node-name: %v
 		t.Fatal(err)
 	}
 	overrides := make(map[string]string)
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/local/jvmcollect/heap_dump_test.go
+++ b/cmd/local/jvmcollect/heap_dump_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/jvmcollect"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/tests"
 )
 
@@ -78,7 +79,7 @@ dremio-pid: %v
 	if err := os.WriteFile(ddcYaml, []byte(ddcYamlString), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/local/jvmcollect/jfr_test.go
+++ b/cmd/local/jvmcollect/jfr_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/jvmcollect"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 	"github.com/dremio/dremio-diagnostic-collector/pkg/simplelog"
 )
 
@@ -86,7 +87,7 @@ dremio-jfr-time-seconds: 2
 	if err := os.WriteFile(ddcYaml, []byte(ddcYamlString), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +190,7 @@ dremio-jfr-time-seconds: 2
 	if err := os.WriteFile(ddcYaml, []byte(ddcYamlString), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/local/jvmcollect/jstack_test.go
+++ b/cmd/local/jvmcollect/jstack_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/jvmcollect"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 )
 
 func TestJStackCapture(t *testing.T) {
@@ -73,7 +74,7 @@ dremio-jstack-freq-seconds: 1
 	if err := os.WriteFile(ddcYaml, []byte(ddcYamlString), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/local/jvmcollect/jvm_flags_test.go
+++ b/cmd/local/jvmcollect/jvm_flags_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/conf"
 	"github.com/dremio/dremio-diagnostic-collector/cmd/local/jvmcollect"
+	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 )
 
 func TestJvmFlagsAreWritten(t *testing.T) {
@@ -68,7 +69,7 @@ dremio-pid: %v
 	if err := os.WriteFile(ddcYaml, []byte(ddcYamlString), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, err := conf.ReadConf(overrides, ddcYaml)
+	c, err := conf.ReadConf(overrides, ddcYaml, collects.StandardCollection)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integrationtest/ssh/collect_ssh_test.go
+++ b/integrationtest/ssh/collect_ssh_test.go
@@ -351,7 +351,7 @@ Error was: %v`, err)
 	if err := os.WriteFile(ddcYaml, []byte("#comment"), 0600); err != nil {
 		t.Fatalf("unable to write ddc yaml: %v", err)
 	}
-	args := []string{"ddc", "-s", privateKey, "-u", sshConf.User, "--sudo-user", sshConf.SudoUser, "-c", sshConf.Coordinator, "-e", sshConf.Executor, "--ddc-yaml", ddcYaml, "--collect", "wrong"}
+	args := []string{"ddc", "-s", privateKey, "-u", sshConf.User, "--sudo-user", sshConf.SudoUser, "-c", sshConf.Coordinator, "-e", sshConf.Executor, "--ddc-yaml", ddcYaml, "--collect", "wrong", "--" + conf.KeyDisableFreeSpaceCheck}
 	err = cmd.Execute(args)
 	if err == nil {
 		t.Error("collect should fail")


### PR DESCRIPTION
* validation for the local-collect command was in a weird place leading to lots of state issues in tests. now it will happen strictly in the initial cli parsing where there are less moving parts