### PR TITLE
better job profile collection defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.3.0] - 2024-03-28
+
+### Changed
+
+* the default job profiles is now 20 for everything except the health check where it remains 25000. This default only works if
+someone has added the PAT which is always available
+* moved all rest API calls to the start of the process. This is to minimize the amount of operations that fails if a token expires.
+
 ## [2.3.0-rc3] - 2024-03-26
 
 ### Fixed
@@ -599,6 +607,7 @@
 
 - able to capture logs, configuration and diagnostic data from dremio clusters deployed on Kubernetes and on-prem
 
+[2.3.0]: https://github.com/dremio/dremio-diagnostic-collector/compare/v2.3.0-rc3...v2.3.0
 [2.3.0-rc3]: https://github.com/dremio/dremio-diagnostic-collector/compare/v2.3.0-rc2...v2.3.0-rc3
 [2.3.0-rc2]: https://github.com/dremio/dremio-diagnostic-collector/compare/v2.3.0-rc1...v2.3.0-rc2
 [2.3.0-rc1]: https://github.com/dremio/dremio-diagnostic-collector/compare/v2.3.0-beta3...v2.3.0-rc1

--- a/cmd/local/conf/defaults.go
+++ b/cmd/local/conf/defaults.go
@@ -41,6 +41,11 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 		setDefault(confData, KeyDremioQueriesJSONNumDays, 30)
 		setDefault(confData, KeyNumberThreads, 2)
 	}
+	if collectionMode == collects.HealthCheckCollection {
+		setDefault(confData, KeyNumberJobProfiles, 25000)
+	} else {
+		setDefault(confData, KeyNumberJobProfiles, 20)
+	}
 
 	// set default config
 	setDefault(confData, KeyCollectJStack, false)
@@ -59,7 +64,6 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 	setDefault(confData, KeyDremioRocksdbDir, "/opt/dremio/data/db")
 	setDefault(confData, KeyCollectDremioConfiguration, true)
 	setDefault(confData, KeyCaptureHeapDump, false)
-	setDefault(confData, KeyNumberJobProfiles, 25000)
 	setDefault(confData, KeyDremioEndpoint, "http://localhost:9047")
 	setDefault(confData, KeyTarballOutDir, "/tmp/ddc")
 	setDefault(confData, KeyCollectOSConfig, true)

--- a/cmd/local/conf/defaults_test.go
+++ b/cmd/local/conf/defaults_test.go
@@ -23,18 +23,18 @@ import (
 	"github.com/dremio/dremio-diagnostic-collector/pkg/collects"
 )
 
-func setupTestSetViperDefaults() (map[string]interface{}, string, int) {
+func setupTestSetViperDefaults(collectionType string) (map[string]interface{}, string, int) {
 	hostName := "test-host"
 	defaultCaptureSeconds := 30
 	confData := make(map[string]interface{})
 	// Run the function.
-	conf.SetViperDefaults(confData, hostName, defaultCaptureSeconds, collects.StandardCollection)
+	conf.SetViperDefaults(confData, hostName, defaultCaptureSeconds, collectionType)
 
 	return confData, hostName, defaultCaptureSeconds
 }
 
-func TestSetViperDefaults(t *testing.T) {
-	confData, hostName, defaultCaptureSeconds := setupTestSetViperDefaults()
+func TestSetViperDefaultsWithHealthCheck(t *testing.T) {
+	confData, hostName, defaultCaptureSeconds := setupTestSetViperDefaults(collects.HealthCheckCollection)
 
 	checks := []struct {
 		key      string
@@ -56,6 +56,124 @@ func TestSetViperDefaults(t *testing.T) {
 		{conf.KeyCollectDremioConfiguration, true},
 		{conf.KeyCaptureHeapDump, false},
 		{conf.KeyNumberJobProfiles, 25000},
+		{conf.KeyDremioEndpoint, "http://localhost:9047"},
+		{conf.KeyTarballOutDir, "/tmp/ddc"},
+		{conf.KeyCollectOSConfig, true},
+		{conf.KeyCollectDiskUsage, true},
+		{conf.KeyDremioLogsNumDays, 7},
+		{conf.KeyDremioQueriesJSONNumDays, 30},
+		{conf.KeyDremioGCFilePattern, "gc*.log*"},
+		{conf.KeyCollectQueriesJSON, true},
+		{conf.KeyCollectServerLogs, true},
+		{conf.KeyCollectMetaRefreshLog, true},
+		{conf.KeyCollectReflectionLog, true},
+		{conf.KeyCollectGCLogs, true},
+		{conf.KeyCollectJFR, true},
+		{conf.KeyCollectJStack, false},
+		{conf.KeyCollectSystemTablesExport, true},
+		{conf.KeyCollectWLM, true},
+		{conf.KeyCollectTtop, true},
+		{conf.KeyCollectKVStoreReport, true},
+		{conf.KeyDremioJStackTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioJFRTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioJStackFreqSeconds, 1},
+		{conf.KeyDremioTtopFreqSeconds, 1},
+		{conf.KeyDremioTtopTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioGCLogsDir, ""},
+		{conf.KeyNodeName, hostName},
+		{conf.KeyAcceptCollectionConsent, true},
+		{conf.KeyAllowInsecureSSL, true},
+	}
+
+	for _, check := range checks {
+		actual := confData[check.key]
+		if actual != check.expected {
+			t.Errorf("Unexpected value for '%s'. Got %v, expected %v", check.key, actual, check.expected)
+		}
+	}
+}
+
+func TestSetViperDefaultsQuickCollect(t *testing.T) {
+	confData, hostName, defaultCaptureSeconds := setupTestSetViperDefaults(collects.QuickCollection)
+	checks := []struct {
+		key      string
+		expected interface{}
+	}{
+		{conf.KeyDisableRESTAPI, false},
+		{conf.KeyCollectAccelerationLog, false},
+		{conf.KeyCollectAccessLog, false},
+		{conf.KeyCollectAuditLog, false},
+		{conf.KeyCollectJVMFlags, true},
+		{conf.KeyDremioLogDir, "/var/log/dremio"},
+		{conf.KeyNumberThreads, 1},
+		{conf.KeyDremioPid, 0},
+		{conf.KeyDremioPidDetection, true},
+		{conf.KeyDremioUsername, "dremio"},
+		{conf.KeyDremioPatToken, ""},
+		{conf.KeyDremioConfDir, "/opt/dremio/conf"},
+		{conf.KeyDremioRocksdbDir, "/opt/dremio/data/db"},
+		{conf.KeyCollectDremioConfiguration, true},
+		{conf.KeyCaptureHeapDump, false},
+		{conf.KeyNumberJobProfiles, 20},
+		{conf.KeyDremioEndpoint, "http://localhost:9047"},
+		{conf.KeyTarballOutDir, "/tmp/ddc"},
+		{conf.KeyCollectOSConfig, true},
+		{conf.KeyCollectDiskUsage, true},
+		{conf.KeyDremioLogsNumDays, 2},
+		{conf.KeyDremioQueriesJSONNumDays, 2},
+		{conf.KeyDremioGCFilePattern, "gc*.log*"},
+		{conf.KeyCollectQueriesJSON, true},
+		{conf.KeyCollectServerLogs, true},
+		{conf.KeyCollectMetaRefreshLog, true},
+		{conf.KeyCollectReflectionLog, true},
+		{conf.KeyCollectGCLogs, true},
+		{conf.KeyCollectJFR, false},
+		{conf.KeyCollectJStack, false},
+		{conf.KeyCollectSystemTablesExport, true},
+		{conf.KeyCollectWLM, true},
+		{conf.KeyCollectTtop, false},
+		{conf.KeyCollectKVStoreReport, true},
+		{conf.KeyDremioJStackTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioJFRTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioJStackFreqSeconds, 1},
+		{conf.KeyDremioTtopFreqSeconds, 1},
+		{conf.KeyDremioTtopTimeSeconds, defaultCaptureSeconds},
+		{conf.KeyDremioGCLogsDir, ""},
+		{conf.KeyNodeName, hostName},
+		{conf.KeyAcceptCollectionConsent, true},
+		{conf.KeyAllowInsecureSSL, true},
+	}
+
+	for _, check := range checks {
+		actual := confData[check.key]
+		if actual != check.expected {
+			t.Errorf("Unexpected value for '%s'. Got %v, expected %v", check.key, actual, check.expected)
+		}
+	}
+}
+
+func TestSetViperDefaults(t *testing.T) {
+	confData, hostName, defaultCaptureSeconds := setupTestSetViperDefaults(collects.StandardCollection)
+	checks := []struct {
+		key      string
+		expected interface{}
+	}{
+		{conf.KeyDisableRESTAPI, false},
+		{conf.KeyCollectAccelerationLog, false},
+		{conf.KeyCollectAccessLog, false},
+		{conf.KeyCollectAuditLog, false},
+		{conf.KeyCollectJVMFlags, true},
+		{conf.KeyDremioLogDir, "/var/log/dremio"},
+		{conf.KeyNumberThreads, 2},
+		{conf.KeyDremioPid, 0},
+		{conf.KeyDremioPidDetection, true},
+		{conf.KeyDremioUsername, "dremio"},
+		{conf.KeyDremioPatToken, ""},
+		{conf.KeyDremioConfDir, "/opt/dremio/conf"},
+		{conf.KeyDremioRocksdbDir, "/opt/dremio/data/db"},
+		{conf.KeyCollectDremioConfiguration, true},
+		{conf.KeyCaptureHeapDump, false},
+		{conf.KeyNumberJobProfiles, 20},
 		{conf.KeyDremioEndpoint, "http://localhost:9047"},
 		{conf.KeyTarballOutDir, "/tmp/ddc"},
 		{conf.KeyCollectOSConfig, true},

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -14,7 +14,7 @@
 # collect-access-log: false
 # collect-audit-log: false
 # collect-dremio-configuration: true # will collect dremio.conf, dremio-env, logback.xml and logback-access.xml
-# number-job-profiles: 25000 # up to this number, may have less due to duplicates NOTE: need to have the dremio-pat-token set to work
+# number-job-profiles: 20 # this is 25000 when a health check is selected up to this number, may have less due to duplicates NOTE: need to have the dremio-pat-token set to work
 # capture-heap-dump: false # when true a heap dump will be captured on each node that the collector is run against
 # accept-collection-consent: true # when true you accept consent to collect data on each node, if false collection will fail
 # allow-insecure-ssl: true # when true skip the ssl cert check when doing API calls


### PR DESCRIPTION
* when doing light and health check and the pat is added will collect 20
  profiles
* moved rest collection except job profiles to front of collection to
  avoid bearer token expiration at the end of the job
