### PR TITLE
support for custom kubernetes context with ddc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [3.2.3] - 2024-09-06
 
+### Added
+
+* --context or -x flag to provide support for passing the kubernetes context into ddc, this works for both the 
+kubeAPI as well as the the kubectl based collection
+* the current context is detected if none is supplied
+* added the context used to the logs
+* added the context used to the collection type output
+* we now log the URL of the kubernetes REST api server
+
 ### Removed
 
 * extra log showing free disk space was confusing so it has been removed
@@ -759,6 +768,8 @@ someone has added the PAT which is always available
 
 - able to capture logs, configuration and diagnostic data from Dremio clusters deployed on Kubernetes and on-prem
  
+[3.2.3]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.2...v3.2.3
+[3.2.2]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.1...v3.2.2
 [3.2.1]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.1.2...v3.2.0
 [3.1.2]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.1.1...v3.1.2

--- a/pkg/consoleprint/consoleprint.go
+++ b/pkg/consoleprint/consoleprint.go
@@ -45,6 +45,7 @@ type CollectionStats struct {
 	TransfersComplete    int
 	totalTransfers       int
 	collectionType       string
+	k8sContext           string
 	tarball              string
 	nodeCaptureStats     map[string]*NodeCaptureStats
 	nodeDetectDisabled   map[string]bool
@@ -58,6 +59,13 @@ type CollectionStats struct {
 	endTime              int64
 	warnings             []string
 	mu                   sync.RWMutex // Mutex to protect access
+}
+
+func (c *CollectionStats) GetCollectionType() string {
+	if c.k8sContext == "" {
+		return c.collectionType
+	}
+	return fmt.Sprintf("%v - context used: %v", c.collectionType, c.k8sContext)
 }
 
 var statusOut bool
@@ -158,6 +166,12 @@ func UpdateCollectionMode(collectionMode string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.collectionMode = collectionMode
+}
+
+func UpdateK8SContext(k8sContext string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.k8sContext = k8sContext
 }
 
 // AddWarningToConsole adds a trimed string to the list of warnings
@@ -363,7 +377,7 @@ Result               : %v
 
 
 %v
-`, time.Now().Format(time.RFC1123), strings.TrimSpace(ddcVersion), c.ddcYaml, c.logFile, c.collectionType, strings.Join(c.enabled, ","), strings.Join(c.disabled, ","), strings.ToUpper(c.collectionMode), c.collectionArgs, patMessage, autodetectEnabled, c.TransfersComplete, total,
+`, time.Now().Format(time.RFC1123), strings.TrimSpace(ddcVersion), c.ddcYaml, c.logFile, c.GetCollectionType(), strings.Join(c.enabled, ","), strings.Join(c.disabled, ","), strings.ToUpper(c.collectionMode), c.collectionArgs, patMessage, autodetectEnabled, c.TransfersComplete, total,
 		durationElapsed, c.tarball, c.result, warningsBuilder.String(), nodes.String())
 	c.mu.Unlock()
 


### PR DESCRIPTION
Reduced the number of connections to k8s..that was excessive prior, and now I log the context used
Also now log the output of the current context if none is set and display this in the UI to make it more obvoius which one is in use