### PR TITLE
fix custom label for kubectl strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.1] - 2024-01-09
+
+### Fixed
+
+* -l selector was not being applied when kubectl was available
+
 ## [3.3.0] - 2024-01-03
 
 ### Added
@@ -838,6 +844,7 @@ someone has added the PAT which is always available
 
 - able to capture logs, configuration and diagnostic data from Dremio clusters deployed on Kubernetes and on-prem
 
+[3.3.1]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.8...v3.3.0
 [3.2.8]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.7...v3.2.8
 [3.2.7]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.2.6...v3.2.7

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,7 +183,7 @@ func RemoteCollect(collectionArgs collection.Args, sshArgs ssh.Args, kubeArgs ku
 			return err
 		}
 		if !disableKubeCtl {
-			potentialStrategy, err := kubectl.NewKubectlK8sActions(hook, kubeArgs.Namespace, kubeArgs.K8SContext)
+			potentialStrategy, err := kubectl.NewKubectlK8sActions(hook, kubeArgs)
 			if err != nil {
 				simplelog.Warningf("kubectl not available failling back to kubeapi: %v", err)
 			} else {

--- a/cmd/root/kubectl/kubectl_test.go
+++ b/cmd/root/kubectl/kubectl_test.go
@@ -75,10 +75,11 @@ func TestKubectlSearch(t *testing.T) {
 		StoredErrors:   []error{nil, nil, nil, nil},
 	}
 	k := CliK8sActions{
-		cli:         cli,
-		kubectlPath: "kubectl",
-		namespace:   namespace,
-		k8sContext:  k8sContext,
+		cli:           cli,
+		labelSelector: "role=dremio-pods",
+		kubectlPath:   "kubectl",
+		namespace:     namespace,
+		k8sContext:    k8sContext,
 	}
 	podNames, err := k.GetCoordinators()
 	if err != nil {
@@ -95,7 +96,7 @@ func TestKubectlSearch(t *testing.T) {
 	if len(calls) != 4 {
 		t.Errorf("expected 4 call but got %v", len(calls))
 	}
-	expectedCall := []string{"kubectl", "get", "pods", "-n", namespace, "--context", k8sContext, "-l", "role=dremio-cluster-pod", "-o", "name"}
+	expectedCall := []string{"kubectl", "get", "pods", "-n", namespace, "--context", k8sContext, "-l", "role=dremio-pods", "-o", "name"}
 	if !reflect.DeepEqual(calls[0], expectedCall) {
 		t.Errorf("\nexpected call\n%v\nbut got\n%v", expectedCall, calls[0])
 	}
@@ -148,6 +149,7 @@ func TestKubectCopyFromWindowsHost(t *testing.T) {
 	}
 	k := CliK8sActions{
 		cli:            cli,
+		labelSelector:  "role=abc",
 		kubectlPath:    "kubectl",
 		namespace:      namespace,
 		k8sContext:     k8sContext,


### PR DESCRIPTION
- kubectl strategy had hard-coded the default role of role=dremio-cluster-pod, this is now fixed and uses the same kubectl args that is used by the kubernetes api strategy fixes #280 
