### PR TITLE
Parameterize systables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.3] - 2024-03-11
+
+### Added
+
+* added new parameters in ddc.yaml `system-tables` and `system-tables-cloud` to specify which system tables a user wishes to collect. The defaults remain the same as before.
+
 ## [3.3.2] - 2024-02-18
 
 ### Added

--- a/cmd/local/apicollect/system_tables.go
+++ b/cmd/local/apicollect/system_tables.go
@@ -51,25 +51,12 @@ func RunCollectDremioSystemTables(c *conf.CollectConf, hook shutdown.CancelHook)
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if checkSkipSysTable(systable, c) {
-			simplelog.Warningf("Skipping system table %v", systable)
-		} else {
-			err := downloadSysTable(ctx, c, hook, systable)
-			if err != nil {
-				simplelog.Errorf("%v", err) // Print instead of Error
-			}
+		err := downloadSysTable(ctx, c, hook, systable)
+		if err != nil {
+			simplelog.Errorf("%v", err) // Print instead of Error
 		}
 	}
 	return nil
-}
-
-func checkSkipSysTable(systable string, c *conf.CollectConf) bool {
-	for _, skipTable := range c.SkipSysTables() {
-		if skipTable == systable {
-			return true
-		}
-	}
-	return false
 }
 
 func downloadSysTable(ctx context.Context, c *conf.CollectConf, hook shutdown.CancelHook, systable string) error {

--- a/cmd/local/apicollect/system_tables.go
+++ b/cmd/local/apicollect/system_tables.go
@@ -51,12 +51,25 @@ func RunCollectDremioSystemTables(c *conf.CollectConf, hook shutdown.CancelHook)
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		err := downloadSysTable(ctx, c, hook, systable)
-		if err != nil {
-			simplelog.Errorf("%v", err) // Print instead of Error
+		if checkSkipSysTable(systable, c) {
+			simplelog.Warningf("Skipping system table %v", systable)
+		} else {
+			err := downloadSysTable(ctx, c, hook, systable)
+			if err != nil {
+				simplelog.Errorf("%v", err) // Print instead of Error
+			}
 		}
 	}
 	return nil
+}
+
+func checkSkipSysTable(systable string, c *conf.CollectConf) bool {
+	for _, skipTable := range c.SkipSysTables() {
+		if skipTable == systable {
+			return true
+		}
+	}
+	return false
 }
 
 func downloadSysTable(ctx context.Context, c *conf.CollectConf, hook shutdown.CancelHook, systable string) error {

--- a/cmd/local/apicollect/system_tables_test.go
+++ b/cmd/local/apicollect/system_tables_test.go
@@ -17,12 +17,6 @@ package apicollect
 
 import (
 	"testing"
-
-	"github.com/dremio/dremio-diagnostic-collector/v3/cmd/local/conf"
-)
-
-var (
-	testConf *conf.CollectConf
 )
 
 func TestSysTableNameWithNoEscapableCharacters(t *testing.T) {
@@ -63,11 +57,4 @@ func TestSysTableNameWithAllEscapableCharacters(t *testing.T) {
 	if name != expected {
 		t.Errorf("expected %v but was %v", expected, name)
 	}
-}
-
-func TestSysTableSkip(t *testing.T) {
-	var c conf.CollectConf
-	table := c.SkipSysTables()
-	t.Logf("table: %v", table)
-
 }

--- a/cmd/local/apicollect/system_tables_test.go
+++ b/cmd/local/apicollect/system_tables_test.go
@@ -15,7 +15,15 @@
 // apicollect provides all the methods that collect via the API, this is a substantial part of the activities of DDC so it gets it's own package
 package apicollect
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/dremio/dremio-diagnostic-collector/v3/cmd/local/conf"
+)
+
+var (
+	testConf *conf.CollectConf
+)
 
 func TestSysTableNameWithNoEscapableCharacters(t *testing.T) {
 	urlsuffix := ""
@@ -55,4 +63,11 @@ func TestSysTableNameWithAllEscapableCharacters(t *testing.T) {
 	if name != expected {
 		t.Errorf("expected %v but was %v", expected, name)
 	}
+}
+
+func TestSysTableSkip(t *testing.T) {
+	var c conf.CollectConf
+	table := c.SkipSysTables()
+	t.Logf("table: %v", table)
+
 }

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -46,6 +46,14 @@ func GetString(confData map[string]interface{}, key string) string {
 	return ""
 }
 
+func GetStringArray(confData map[string]interface{}, key string) []string {
+	var e []string // empty array to fulfill return for noentry
+	if v, ok := confData[key]; ok {
+		return strings.Split(cast.ToString(v), ",")
+	}
+	return e
+}
+
 func GetInt(confData map[string]interface{}, key string) int {
 	if v, ok := confData[key]; ok {
 		return cast.ToInt(v)
@@ -123,6 +131,7 @@ type CollectConf struct {
 	collectSystemTablesExport         bool
 	collectSystemTablesTimeoutSeconds int
 	systemTablesRowLimit              int
+	skipSysTables                     []string
 	collectClusterIDTimeoutSeconds    int
 	collectOSConfig                   bool
 	collectDiskUsage                  bool
@@ -541,6 +550,7 @@ func ReadConf(hook shutdown.Hook, overrides map[string]string, ddcYamlLoc, colle
 		c.collectWLM = GetBool(confData, KeyCollectWLM)
 		c.collectSystemTablesExport = GetBool(confData, KeyCollectSystemTablesExport)
 		c.systemTablesRowLimit = GetInt(confData, KeySystemTablesRowLimit)
+		c.skipSysTables = GetStringArray(confData, KeySkipSysTables)
 		c.collectKVStoreReport = GetBool(confData, KeyCollectKVStoreReport)
 		restclient.InitClient(c.allowInsecureSSL, c.restHTTPTimeout)
 		// validate rest api configuration
@@ -761,6 +771,10 @@ func (c *CollectConf) CollectKVStoreReport() bool {
 
 func (c *CollectConf) Systemtables() []string {
 	return c.systemtables
+}
+
+func (c *CollectConf) SkipSysTables() []string {
+	return c.skipSysTables
 }
 
 func (c *CollectConf) SystemtablesDremioCloud() []string {

--- a/cmd/local/conf/conf_key_names.go
+++ b/cmd/local/conf/conf_key_names.go
@@ -77,5 +77,6 @@ const (
 	KeyCollectionMode                    = "collect"
 	KeyCollectClusterIDTimeoutSeconds    = "collect-cluster-id-timeout-seconds"
 	KeyCollectSystemTablesTimeoutSeconds = "collect-system-tables-timeout-seconds"
-	KeySkipSysTables                     = "skip-system-table"
+	KeySysTables                         = "system-tables"
+	KeySysTablesCloud                    = "system-tables-cloud"
 )

--- a/cmd/local/conf/conf_key_names.go
+++ b/cmd/local/conf/conf_key_names.go
@@ -77,4 +77,5 @@ const (
 	KeyCollectionMode                    = "collect"
 	KeyCollectClusterIDTimeoutSeconds    = "collect-cluster-id-timeout-seconds"
 	KeyCollectSystemTablesTimeoutSeconds = "collect-system-tables-timeout-seconds"
+	KeySkipSysTables                     = "skip-system-table"
 )

--- a/cmd/local/conf/defaults.go
+++ b/cmd/local/conf/defaults.go
@@ -14,7 +14,9 @@
 
 package conf
 
-import "github.com/dremio/dremio-diagnostic-collector/v3/pkg/collects"
+import (
+	"github.com/dremio/dremio-diagnostic-collector/v3/pkg/collects"
+)
 
 func setDefault(confData map[string]interface{}, key string, value interface{}) {
 	// if key is not present go ahead and set it
@@ -101,4 +103,6 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 	setDefault(confData, KeyNoLogDir, false)
 	setDefault(confData, KeyMinFreeSpaceGB, 40)
 	setDefault(confData, KeyCollectClusterIDTimeoutSeconds, 60)
+	setDefault(confData, KeySysTables, SystemTableList())
+	setDefault(confData, KeySysTablesCloud, SystemTableListCloud())
 }

--- a/cmd/local/conf/defaults_test.go
+++ b/cmd/local/conf/defaults_test.go
@@ -17,6 +17,7 @@
 package conf_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/dremio/dremio-diagnostic-collector/v3/cmd/local/conf"
@@ -87,12 +88,14 @@ func TestSetViperDefaultsWithHealthCheck(t *testing.T) {
 		{conf.KeyCollectSystemTablesTimeoutSeconds, 1440},
 		{conf.KeyCollectClusterIDTimeoutSeconds, 60},
 		{conf.KeyNoLogDir, false},
+		{conf.KeySysTables, conf.SystemTableList()},
+		{conf.KeySysTablesCloud, conf.SystemTableListCloud()},
 	}
 
 	for _, check := range checks {
-		actual := confData[check.key]
-		if actual != check.expected {
-			t.Errorf("Unexpected value for '%s'. Got %v, expected %v", check.key, actual, check.expected)
+		actual := fmt.Sprint(confData[check.key])
+		if actual != fmt.Sprint(check.expected) {
+			t.Errorf("Unexpected value for '%s'. \nGot:\n %v\nExpected:\n %v", check.key, actual, check.expected)
 		}
 	}
 }
@@ -151,8 +154,8 @@ func TestSetViperDefaultsQuickCollect(t *testing.T) {
 	}
 
 	for _, check := range checks {
-		actual := confData[check.key]
-		if actual != check.expected {
+		actual := fmt.Sprint(confData[check.key])
+		if actual != fmt.Sprint(check.expected) {
 			t.Errorf("Unexpected value for '%s'. Got %v, expected %v", check.key, actual, check.expected)
 		}
 	}
@@ -212,8 +215,8 @@ func TestSetViperDefaults(t *testing.T) {
 	}
 
 	for _, check := range checks {
-		actual := confData[check.key]
-		if actual != check.expected {
+		actual := fmt.Sprint(confData[check.key])
+		if actual != fmt.Sprint(check.expected) {
 			t.Errorf("Unexpected value for '%s'. Got %v, expected %v", check.key, actual, check.expected)
 		}
 	}

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -44,6 +44,7 @@
 # collect-system-tables-timeout-seconds: 120
 # collect-cluster-id-timeout-seconds: 60
 # system-tables-row-limit: 100000
+# skip-system-table: # csv list of system tables to skip
 # collect-wlm: true
 # collect-kvstore-report: true
 # dremio-jstack-time-seconds: 60

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -44,7 +44,48 @@
 # collect-system-tables-timeout-seconds: 120
 # collect-cluster-id-timeout-seconds: 60
 # system-tables-row-limit: 100000
-# skip-system-table: # csv list of system tables to skip
+# system-tables: 
+#  - "\\\"tables\\\""
+#  - "copy_errors_history"
+#  - "fragments"
+#  - "jobs"
+#  - "materializations"
+#  - "membership"
+#  - "memory"
+#  - "nodes"
+#  - "options"
+#  - "privileges"
+#  - "reflection_dependencies"
+#  - "reflections"
+#  - "refreshes"
+#  - "roles"
+#  - "services"
+#  - "slicing_threads"
+#  - "table_statistics"
+#  - "threads"
+#  - "user_defined_functions"
+#  - "version"
+#  - "views"
+#  - "cache.datasets"
+#  - "cache.mount_points"
+#  - "cache.storage_plugins"
+#  - "jobs_recent"
+# system-tables-cloud: 	
+#  - "organization.clouds"
+#  - "organization.privileges"
+#  - "organization.projects"
+#  - "organization.roles"
+#  - "organization.usage"
+#  - "project.engines"
+#  - "project.jobs"
+#  - "project.materializations"
+#  - "project.privileges"
+#  - "project.reflection_dependencies"
+#  - "project.reflections"
+#  - "project.\\\"tables\\\""
+#  - "project.views"
+#  - // "project.history.events"
+#  - "project.history.jobs"
 # collect-wlm: true
 # collect-kvstore-report: true
 # dremio-jstack-time-seconds: 60


### PR DESCRIPTION
During some health checks although system tables are needed there may be a need to exclude some system tables, in particular jobs_recent as it can be quite large

This change adds the following parameter into the `ddc.yaml` for example

```
skip-system-table: jobs,jobs_recent # csv list of system tables to skip
```

allows you to include a list of tables you might want to skip