### PR TITLE
added "is-rest-collect" mode to allow DDC via REST API only

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Log-only collection from a Dremio AWSE coordinator is possible via the following
 ./ddc awselogs
 ```
 
+### REST-API-only collection (works for all Dremio Software variants)
+To collect job profiles, system tables, and wlm via REST API, specify the following parameters in `ddc.yaml`
+```yaml
+is-rest-collect: true
+dremio-endpoint: "<DREMIO_ENDPOINT>"
+dremio-pat-token: "<DREMIO_PAT>"
+tarball-out-dir: /full/path/to/local/dir  # Specify local target directory
+```
+and run `./ddc local-collect` from your local machine
+
 ### Dremio Cloud
 To collect job profiles, system tables, and wlm via REST API, specify the following parameters in `ddc.yaml`
 ```yaml
@@ -94,7 +104,7 @@ is-dremio-cloud: true
 dremio-endpoint: "[eu.]dremio.cloud"    # Specify whether EU Dremio Cloud or not
 dremio-cloud-project-id: "<PROJECT_ID>"
 dremio-pat-token: "<DREMIO_PAT>"
-tmp-output-dir: /full/path/to/dir       # Specify local target directory
+tarball-out-dir: /full/path/to/dir      # Specify local target directory
 ```
 and run `./ddc local-collect` from your local machine
 

--- a/cmd/local/apicollect/jobprofiles.go
+++ b/cmd/local/apicollect/jobprofiles.go
@@ -49,8 +49,8 @@ func GetNumberOfJobProfilesCollected(c *conf.CollectConf, hook shutdown.Hook) (t
 	}
 
 	if len(jobhistoryjsons) == 0 {
-		// Attempt to read job history from queries.json, if not Dremio Cloud
-		if !c.IsDremioCloud() {
+		// Attempt to read job history from queries.json, if not Dremio Cloud or REST collect
+		if !c.IsRESTCollect() {
 			files, err = os.ReadDir(c.QueriesOutDir())
 			if err != nil {
 				return 0, 0, err

--- a/cmd/local/conf/conf_key_names.go
+++ b/cmd/local/conf/conf_key_names.go
@@ -63,6 +63,7 @@ const (
 	KeyDremioGCLogsDir                   = "dremio-gclogs-dir"
 	KeyNodeName                          = "node-name"
 	KeyAcceptCollectionConsent           = "accept-collection-consent"
+	KeyIsRESTCollect                     = "is-rest-collect"
 	KeyIsDremioCloud                     = "is-dremio-cloud"
 	KeyDremioCloudProjectID              = "dremio-cloud-project-id"
 	KeyAllowInsecureSSL                  = "allow-insecure-ssl"

--- a/cmd/local/conf/conf_test.go
+++ b/cmd/local/conf/conf_test.go
@@ -132,6 +132,7 @@ var afterEachConfTest = func() {
 
 func TestConfReadingWithEUDremioCloud(t *testing.T) {
 	genericConfSetup(`
+is-rest-collect: false
 is-dremio-cloud: true
 dremio-cloud-project-id: "224653935291683895642623390599291234"
 dremio-endpoint: eu.dremio.cloud
@@ -147,6 +148,9 @@ dremio-endpoint: eu.dremio.cloud
 		t.Error("invalid conf")
 	}
 
+	if cfg.IsRESTCollect() != true {
+		t.Error("expected is-rest-collect to be flipped to true")
+	}
 	if cfg.IsDremioCloud() != true {
 		t.Error("expected is-dremio-cloud to be true")
 	}
@@ -257,6 +261,9 @@ dremio-endpoint: dremio.cloud
 		t.Error("invalid conf")
 	}
 
+	if cfg.IsRESTCollect() != true {
+		t.Error("expected is-rest-collect to be flipped to true")
+	}
 	if cfg.IsDremioCloud() != true {
 		t.Error("expected is-dremio-cloud to be true")
 	}
@@ -386,6 +393,9 @@ func TestConfReadingWithAValidConfigurationFile(t *testing.T) {
 		t.Errorf("expected timeout of 12 seconds for cluster id collection")
 	}
 
+	if cfg.IsRESTCollect() != false {
+		t.Error("expected is-rest-collect to be false")
+	}
 	afterEachConfTest()
 }
 

--- a/cmd/local/conf/defaults.go
+++ b/cmd/local/conf/defaults.go
@@ -95,6 +95,7 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 	setDefault(confData, KeyDremioGCLogsDir, "")
 	setDefault(confData, KeyNodeName, hostName)
 	setDefault(confData, KeyAcceptCollectionConsent, true)
+	setDefault(confData, KeyIsRESTCollect, false)
 	setDefault(confData, KeyIsDremioCloud, false)
 	setDefault(confData, KeyDremioCloudProjectID, "")
 	setDefault(confData, KeyAllowInsecureSSL, true)

--- a/cmd/local/conf/defaults_test.go
+++ b/cmd/local/conf/defaults_test.go
@@ -90,6 +90,8 @@ func TestSetViperDefaultsWithHealthCheck(t *testing.T) {
 		{conf.KeyNoLogDir, false},
 		{conf.KeySysTables, conf.SystemTableList()},
 		{conf.KeySysTablesCloud, conf.SystemTableListCloud()},
+		{conf.KeyIsRESTCollect, false},
+		{conf.KeyIsDremioCloud, false},
 	}
 
 	for _, check := range checks {
@@ -151,6 +153,8 @@ func TestSetViperDefaultsQuickCollect(t *testing.T) {
 		{conf.KeyAcceptCollectionConsent, true},
 		{conf.KeyAllowInsecureSSL, true},
 		{conf.KeyNoLogDir, false},
+		{conf.KeyIsRESTCollect, false},
+		{conf.KeyIsDremioCloud, false},
 	}
 
 	for _, check := range checks {
@@ -212,6 +216,8 @@ func TestSetViperDefaults(t *testing.T) {
 		{conf.KeyAcceptCollectionConsent, true},
 		{conf.KeyAllowInsecureSSL, true},
 		{conf.KeyNoLogDir, false},
+		{conf.KeyIsRESTCollect, false},
+		{conf.KeyIsDremioCloud, false},
 	}
 
 	for _, check := range checks {

--- a/cmd/testdata/ddc-valid.yaml
+++ b/cmd/testdata/ddc-valid.yaml
@@ -49,6 +49,7 @@ dremio-pat-token: "my-pat" # when set will attempt to collect Workload Manager, 
 # dremio-ttop-time-seconds: 60
 # dremio-ttop-freq-seconds: 1
 # node-name: "" //dynamically set normally
+# is-rest-collect: false
 # is-dremio-cloud: false
 # dremio-cloud-project-id: ""
 # allow-insecure-ssl: true

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -94,6 +94,7 @@
 # dremio-ttop-time-seconds: 60
 # dremio-ttop-freq-seconds: 1
 # node-name: "" //dynamically set normally
+# is-rest-collect: false
 # is-dremio-cloud: false
 # dremio-cloud-project-id: ""
 # allow-insecure-ssl: true


### PR DESCRIPTION
added "is-rest-collect" mode to allow DDC via REST API only (similar to "is-dremio-cloud" collect mode, but for Dremio Software).

This mode can be run as "local-collect" and will collect the following via REST:
- System tables (incl. sys.jobs_recent)
- Job Profiles
- WLM
- KV store report