### PR TITLE
introduced selective collection of sys.jobs_recent based on collection mode and cluster size

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Log-only collection from a Dremio AWSE coordinator is possible via the following
 To collect job profiles, system tables, and wlm via REST API, specify the following parameters in `ddc.yaml`
 ```yaml
 is-rest-collect: true
+rest-collect-daily-jobs-limit: 100000 # Optional; Used to prevent reading from large sys.jobs_recent table
 dremio-endpoint: "<DREMIO_ENDPOINT>"
 dremio-pat-token: "<DREMIO_PAT>"
 tarball-out-dir: /full/path/to/local/dir  # Specify local target directory

--- a/cmd/local/apicollect/system_tables_test.go
+++ b/cmd/local/apicollect/system_tables_test.go
@@ -58,3 +58,39 @@ func TestSysTableNameWithAllEscapableCharacters(t *testing.T) {
 		t.Errorf("expected %v but was %v", expected, name)
 	}
 }
+
+func TestClusterUsageData(t *testing.T) {
+	filename := "../../testdata/queries/cluster_usage.json"
+	data, _ := openJSON(filename)
+	averageDailyJobCount, _ := calculateJobCount(data)
+	expected := 4580 / (7 + 1) // == 654
+	if averageDailyJobCount != expected {
+		t.Errorf("expected %v but was %v", expected, averageDailyJobCount)
+	}
+}
+
+func TestNoFile(t *testing.T) {
+	filename := "../../testdata/this_file_does_not_exist"
+	_, err := openJSON(filename)
+	if err == nil {
+		t.Errorf("expected file not found error")
+	}
+}
+
+func TestWrongJSON(t *testing.T) {
+	filename := "../../testdata/queries/bad_sys.jobs_recent.json"
+	data, err := openJSON(filename)
+	_, err = calculateJobCount(data)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestInvalidJSON(t *testing.T) {
+	filename := "../../testdata/queries/bad_queries.json"
+	data, err := openJSON(filename)
+	_, err = calculateJobCount(data)
+	if err == nil {
+		t.Errorf("expected error, due to invalid json structure")
+	}
+}

--- a/cmd/local/apicollect/wlm.go
+++ b/cmd/local/apicollect/wlm.go
@@ -44,6 +44,10 @@ func RunCollectWLM(c *conf.CollectConf, hook shutdown.CancelHook) error {
 			{"/api/v3/wlm/queue", "queues.json"},
 			{"/api/v3/wlm/rule", "rules.json"},
 			{"/apiv2/provision/clusters", "awse_engines.json"},
+			{"/apiv2/stats/jobsandusers", "cluster_usage.json"},
+			// {"/api/v3/cluster/stats", "cluster_stats.json"},
+			// {"/api/v3/cluster/jobstats", "cluster_jobstats.json"},
+			// {"/api/v3/stats/user", "cluster_userstats.json"},
 		}
 	} else {
 		apiobjects = [][]string{

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -100,6 +100,7 @@ type CollectConf struct {
 	collectJVMFlags            bool
 	captureHeapDump            bool
 	isRESTCollect              bool
+	restCollectDailyJobsLimit  int
 	isDremioCloud              bool
 	dremioCloudProjectID       string
 	dremioCloudAppEndpoint     string
@@ -208,7 +209,7 @@ func SystemTableList() []string {
 		"cache.datasets",
 		"cache.mount_points",
 		"cache.storage_plugins",
-		"jobs_recent",
+		// "jobs_recent", // Only collected for REST-only collections
 	}
 }
 
@@ -277,6 +278,7 @@ func ReadConf(hook shutdown.Hook, overrides map[string]string, ddcYamlLoc, colle
 	} else {
 		c.isRESTCollect = GetBool(confData, KeyIsRESTCollect)
 	}
+	c.restCollectDailyJobsLimit = GetInt(confData, KeyRESTCollectDailyJobsLimit)
 	c.dremioPIDDetection = GetBool(confData, KeyDremioPidDetection)
 	c.dremioCloudProjectID = GetString(confData, KeyDremioCloudProjectID)
 	c.collectAccelerationLogs = GetBool(confData, KeyCollectAccelerationLog)
@@ -879,6 +881,10 @@ func (c *CollectConf) DremioPATToken() string {
 
 func (c *CollectConf) IsRESTCollect() bool {
 	return c.isRESTCollect
+}
+
+func (c *CollectConf) RestCollectDailyJobsLimit() int {
+	return c.restCollectDailyJobsLimit
 }
 
 func (c *CollectConf) IsDremioCloud() bool {

--- a/cmd/local/conf/conf_key_names.go
+++ b/cmd/local/conf/conf_key_names.go
@@ -64,6 +64,7 @@ const (
 	KeyNodeName                          = "node-name"
 	KeyAcceptCollectionConsent           = "accept-collection-consent"
 	KeyIsRESTCollect                     = "is-rest-collect"
+	KeyRESTCollectDailyJobsLimit         = "rest-collect-daily-jobs-limit"
 	KeyIsDremioCloud                     = "is-dremio-cloud"
 	KeyDremioCloudProjectID              = "dremio-cloud-project-id"
 	KeyAllowInsecureSSL                  = "allow-insecure-ssl"

--- a/cmd/local/conf/defaults.go
+++ b/cmd/local/conf/defaults.go
@@ -96,6 +96,7 @@ func SetViperDefaults(confData map[string]interface{}, hostName string, defaultC
 	setDefault(confData, KeyNodeName, hostName)
 	setDefault(confData, KeyAcceptCollectionConsent, true)
 	setDefault(confData, KeyIsRESTCollect, false)
+	setDefault(confData, KeyRESTCollectDailyJobsLimit, 100000)
 	setDefault(confData, KeyIsDremioCloud, false)
 	setDefault(confData, KeyDremioCloudProjectID, "")
 	setDefault(confData, KeyAllowInsecureSSL, true)

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -728,7 +728,9 @@ func Execute(args []string, overrides map[string]string) (string, error) {
 			simplelog.Errorf("unable to cleanup %v: %v", c.TarballOutDir(), err)
 		}
 	}
-	fmt.Println("looking for logs in: " + c.DremioLogDir())
+	if !c.IsRESTCollect() {
+		fmt.Println("looking for logs in: " + c.DremioLogDir())
+	}
 
 	// Run application
 	simplelog.Info("Starting collection...")

--- a/cmd/testdata/ddc-valid.yaml
+++ b/cmd/testdata/ddc-valid.yaml
@@ -50,6 +50,7 @@ dremio-pat-token: "my-pat" # when set will attempt to collect Workload Manager, 
 # dremio-ttop-freq-seconds: 1
 # node-name: "" //dynamically set normally
 # is-rest-collect: false
+# rest-collect-daily-jobs-limit: 100000
 # is-dremio-cloud: false
 # dremio-cloud-project-id: ""
 # allow-insecure-ssl: true

--- a/cmd/testdata/queries/cluster_usage.json
+++ b/cmd/testdata/queries/cluster_usage.json
@@ -1,0 +1,44 @@
+{
+    "edition": "dremio-ee-25.2.4-202503051912590919-11cc9e3f",
+    "stats": [
+        {
+            "date": "2025-03-06",
+            "jobCount": 3642,
+            "uniqueUsersCount": 7
+        },
+        {
+            "date": "2025-03-07",
+            "jobCount": 187,
+            "uniqueUsersCount": 4
+        },
+        {
+            "date": "2025-03-08",
+            "jobCount": 53,
+            "uniqueUsersCount": 1
+        },
+        {
+            "date": "2025-03-09",
+            "jobCount": 26,
+            "uniqueUsersCount": 1
+        },
+        {
+            "date": "2025-03-10",
+            "jobCount": 422,
+            "uniqueUsersCount": 5
+        },
+        {
+            "date": "2025-03-11",
+            "jobCount": 241,
+            "uniqueUsersCount": 3
+        },
+        {
+            "date": "2025-03-12",
+            "jobCount": 9,
+            "uniqueUsersCount": 1
+        }
+    ],
+    "jobStats": [],
+    "userStatsByDate": [],
+    "userStatsByWeek": [],
+    "userStatsByMonth": []
+}

--- a/default-ddc.yaml
+++ b/default-ddc.yaml
@@ -69,7 +69,6 @@
 #  - "cache.datasets"
 #  - "cache.mount_points"
 #  - "cache.storage_plugins"
-#  - "jobs_recent"
 # system-tables-cloud: 	
 #  - "organization.clouds"
 #  - "organization.privileges"
@@ -95,6 +94,7 @@
 # dremio-ttop-freq-seconds: 1
 # node-name: "" //dynamically set normally
 # is-rest-collect: false
+# rest-collect-daily-jobs-limit: 100000
 # is-dremio-cloud: false
 # dremio-cloud-project-id: ""
 # allow-insecure-ssl: true


### PR DESCRIPTION
- removed sys.jobs_recent from default DDC
- For REST-only DDC, added guardrail for collecting sys.jobs_recent only for small and medium-sized clusters based via "rest-collect-daily-jobs-limit"
- Limited sys.jobs_recent collection to 7 days max