### PR TITLE
Changes to fix #308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.4.1] - 2025-05-15 
+
+### Fixed
+
+* fixed an issue where the `ddc.log` does not get archived if the `--output-file` path is different from the current working dir
+
 ## [3.4.0] - 2025-05-12 
 
 ### Changed
@@ -902,6 +908,7 @@ someone has added the PAT which is always available
 
 - able to capture logs, configuration and diagnostic data from Dremio clusters deployed on Kubernetes and on-prem
 
+[3.4.1]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.3.4...v3.4.0
 [3.3.4]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.3.2...v3.3.3

--- a/cmd/local/conf/conf_test.go
+++ b/cmd/local/conf/conf_test.go
@@ -404,8 +404,9 @@ func TestConfReadingWithAValidConfigurationFile(t *testing.T) {
 
 func TestConfReadingWhenLoggingParsingOfDdcYAML(t *testing.T) {
 	genericConfSetup("")
-	testLog := filepath.Join(t.TempDir(), "ddc.log")
-	simplelog.InitLoggerWithFile(testLog)
+	tempDir := t.TempDir()
+	testLog := filepath.Join(tempDir, "ddc.log")
+	simplelog.InitLoggerWithOutputDir(tempDir)
 	// should log redacted when token is present
 	hook := shutdown.NewHook()
 	defer hook.Cleanup()
@@ -419,7 +420,7 @@ func TestConfReadingWhenLoggingParsingOfDdcYAML(t *testing.T) {
 	if err := simplelog.Close(); err != nil {
 		t.Fatal(err)
 	}
-	defer simplelog.InitLogger()
+	defer simplelog.InitLoggerWithOutputDir(tempDir)
 	b, err := os.ReadFile(testLog)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/local/ddcio/ddcio_test.go
+++ b/cmd/local/ddcio/ddcio_test.go
@@ -153,7 +153,8 @@ func TestEnsureClose(t *testing.T) {
 	expectedFile := "my_long_file_name.txt"
 
 	// so the simplelogger output will be captured
-	simplelog.InitLogger()
+	tempDir := t.TempDir()
+	simplelog.InitLoggerWithOutputDir(tempDir)
 	ddcio.EnsureClose(expectedFile, failedClose)
 
 	raw, err := os.ReadFile(simplelog.GetLogLoc())

--- a/cmd/local/jvmcollect/jfr_test.go
+++ b/cmd/local/jvmcollect/jfr_test.go
@@ -32,9 +32,9 @@ import (
 )
 
 func TestJFRCapture(t *testing.T) {
-	logLoc := filepath.Join(t.TempDir(), "ddc.log")
-
-	simplelog.InitLoggerWithFile(logLoc)
+	tempDir := t.TempDir()
+	logLoc := filepath.Join(tempDir, "ddc.log")
+	simplelog.InitLoggerWithOutputDir(tempDir)
 	jarLoc := filepath.Join("testdata", "demo.jar")
 	cmd := exec.Command("java", "-jar", "-Dmyflag=1", "-Xmx128M", jarLoc)
 	if err := cmd.Start(); err != nil {
@@ -45,7 +45,7 @@ func TestJFRCapture(t *testing.T) {
 		if err != nil {
 			t.Log(err)
 		}
-		simplelog.InitLoggerWithFile(filepath.Join(os.TempDir(), "ddc.log"))
+		simplelog.InitLoggerWithOutputDir(tempDir)
 	}()
 
 	defer func() {
@@ -125,15 +125,15 @@ dremio-jfr-time-seconds: 2
 }
 
 func TestJFRCaptureWithExistingJFR(t *testing.T) {
-	logLoc := filepath.Join(t.TempDir(), "ddc.log")
-
-	simplelog.InitLoggerWithFile(logLoc)
+	tempDir := t.TempDir()
+	logLoc := filepath.Join(tempDir, "ddc.log")
+	simplelog.InitLoggerWithOutputDir(tempDir)
 	defer func() {
 		err := simplelog.Close()
 		if err != nil {
 			t.Log(err)
 		}
-		simplelog.InitLoggerWithFile(filepath.Join(os.TempDir(), "ddc.log"))
+		simplelog.InitLoggerWithOutputDir(os.TempDir())
 	}()
 	jarLoc := filepath.Join("testdata", "demo.jar")
 	cmd := exec.Command("java", "-jar", "-Dmyflag=1", "-Xmx128M", jarLoc)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,6 +283,12 @@ func Execute(args []string) error {
 			return err
 		}
 
+		// Reinitialize logger with output directory if outputLoc is specified
+		if outputLoc != "" {
+			outputDir := filepath.Dir(outputLoc)
+			simplelog.InitLoggerWithOutputDir(outputDir)
+		}
+
 		hook := shutdown.NewHook()
 		defer hook.Cleanup()
 		c := make(chan os.Signal, 1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -275,6 +276,13 @@ func ValidateAndReadYaml(ddcYaml, collectionMode string) (map[string]interface{}
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(args []string) error {
+	// Defer closing the logger
+	defer func() {
+		if err := simplelog.Close(); err != nil {
+			log.Printf("unable to close log: %v", err)
+		}
+	}()
+
 	foundCmd, _, err := RootCmd.Find(args[1:])
 	// default cmd if no cmd is given
 	if err == nil && (foundCmd.Use == RootCmd.Use) && !errors.Is(foundCmd.Flags().Parse(args[1:]), pflag.ErrHelp) {
@@ -283,7 +291,7 @@ func Execute(args []string) error {
 			return err
 		}
 
-		// Reinitialize logger with output directory if outputLoc is specified
+		// Initialize logger after flags have been parsed
 		if outputLoc != "" {
 			outputDir := filepath.Dir(outputLoc)
 			simplelog.InitLoggerWithOutputDir(outputDir)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -170,7 +170,7 @@ func TestValidateDDCYamlNotValid(t *testing.T) {
 func TestValidateDDCYamlMaskPAT(t *testing.T) {
 	tempDir := t.TempDir()
 	// so the simplelogger output will be captured
-	logLoc := filepath.Join(tempDir, "test-ddc.log")
+	logLoc := filepath.Join(tempDir, "ddc.log")
 	simplelog.InitLoggerWithOutputDir(tempDir)
 	defer func() {
 		if err := simplelog.Close(); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -168,13 +168,15 @@ func TestValidateDDCYamlNotValid(t *testing.T) {
 }
 
 func TestValidateDDCYamlMaskPAT(t *testing.T) {
-	logLoc := filepath.Join(t.TempDir(), "test-ddc.log")
-	simplelog.InitLoggerWithFile(logLoc)
+	tempDir := t.TempDir()
+	// so the simplelogger output will be captured
+	logLoc := filepath.Join(tempDir, "test-ddc.log")
+	simplelog.InitLoggerWithOutputDir(tempDir)
 	defer func() {
 		if err := simplelog.Close(); err != nil {
 			t.Logf("unable to close log file %v", err)
 		}
-		simplelog.InitLoggerWithFile(filepath.Join(os.TempDir(), "ddc.log"))
+		simplelog.InitLoggerWithOutputDir(os.TempDir())
 	}()
 	valid := filepath.Join("testdata", "ddc-valid.yaml")
 	_, err := ValidateAndReadYaml(valid, collects.StandardCollection)

--- a/main.go
+++ b/main.go
@@ -16,21 +16,13 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/dremio/dremio-diagnostic-collector/v3/cmd"
 	"github.com/dremio/dremio-diagnostic-collector/v3/pkg/consoleprint"
-	"github.com/dremio/dremio-diagnostic-collector/v3/pkg/simplelog"
 )
 
 func main() {
-	// initial logger before verbosity is parsed
-	defer func() {
-		if err := simplelog.Close(); err != nil {
-			log.Printf("unable to close log: %v", err)
-		}
-	}()
 	if err := cmd.Execute(os.Args); err != nil {
 		consoleprint.ErrorPrint(err.Error())
 		os.Exit(1)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -37,7 +37,7 @@ func TarDDC(srcDir, dest, baseDDC string) error {
 	summaryJSON := filepath.Join(srcDir, "summary.json")
 	ddcFolder := filepath.Join(srcDir, baseDDC)
 	simplelog.Debug("copying log to archive for diagnostics")
-	err := simplelog.CopyLog(filepath.Join(baseDDC, "ddc.log"))
+	err := simplelog.CopyLog(filepath.Join(ddcFolder, "ddc.log"))
 	if err != nil {
 		fmt.Printf("unable to copy ddc.log: \n%v", err)
 	}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -256,7 +256,9 @@ func TestTarDDC(t *testing.T) {
 }
 
 func TestCopyLog(t *testing.T) {
-	simplelog.InitLogger()
+	tempDir := t.TempDir()
+	simplelog.InitLoggerWithOutputDir(tempDir)
+	defer simplelog.InitLoggerWithOutputDir(tempDir)
 	simplelog.Infof("test for copy")
 	currLog := simplelog.GetLogLoc()
 	destLog := filepath.Join("testdata", "ddc.log")

--- a/pkg/simplelog/logger.go
+++ b/pkg/simplelog/logger.go
@@ -97,16 +97,17 @@ func InitLoggerWithFile(fileName string) {
 func InitLoggerWithOutputDir(outputDir string) {
 	ddcLogMut.Lock()
 	defer ddcLogMut.Unlock()
-
 	// Create log file in the specified output directory
-	logPath := filepath.Join(outputDir, "ddc.log")
-	f := createLog(logPath, true)
-	ddcLogLoc := GetLogLoc()
-	logger = newLogger(f, func() {
-		if err := f.Close(); err != nil {
-			fmt.Printf("WARNING unable to close log file: %v\n", ddcLogLoc)
-		}
-	})
+	if outputDir != "" {
+		logPath := filepath.Join(outputDir, "ddc.log")
+		f := createLog(logPath, true)
+		ddcLogLoc := GetLogLoc()
+		logger = newLogger(f, func() {
+			if err := f.Close(); err != nil {
+				fmt.Printf("WARNING unable to close log file: %v\n", ddcLogLoc)
+			}
+		})
+	}
 }
 
 func LogStartMessage() {

--- a/pkg/simplelog/logger.go
+++ b/pkg/simplelog/logger.go
@@ -94,6 +94,21 @@ func InitLoggerWithFile(fileName string) {
 	})
 }
 
+func InitLoggerWithOutputDir(outputDir string) {
+	ddcLogMut.Lock()
+	defer ddcLogMut.Unlock()
+
+	// Create log file in the specified output directory
+	logPath := filepath.Join(outputDir, "ddc.log")
+	f := createLog(logPath, true)
+	ddcLogLoc := GetLogLoc()
+	logger = newLogger(f, func() {
+		if err := f.Close(); err != nil {
+			fmt.Printf("WARNING unable to close log file: %v\n", ddcLogLoc)
+		}
+	})
+}
+
 func LogStartMessage() {
 	var logLine string
 	if GetLogLoc() != "" {

--- a/pkg/simplelog/logger.go
+++ b/pkg/simplelog/logger.go
@@ -82,18 +82,6 @@ func InitLogger() {
 	})
 }
 
-func InitLoggerWithFile(fileName string) {
-	ddcLogMut.Lock()
-	defer ddcLogMut.Unlock()
-	f := createLog(fileName, true)
-	ddcLogLoc := GetLogLoc()
-	logger = newLogger(f, func() {
-		if err := f.Close(); err != nil {
-			fmt.Printf("WARNING unable to close log file: %v\n", ddcLogLoc)
-		}
-	})
-}
-
 func InitLoggerWithOutputDir(outputDir string) {
 	ddcLogMut.Lock()
 	defer ddcLogMut.Unlock()

--- a/pkg/simplelog/logger_test.go
+++ b/pkg/simplelog/logger_test.go
@@ -76,7 +76,9 @@ func TestLogger(t *testing.T) {
 }
 
 func TestStartLogMessage(t *testing.T) {
-	InitLogger()
+	tempDir := t.TempDir()
+	InitLoggerWithOutputDir(tempDir)
+	defer InitLoggerWithOutputDir(tempDir)
 	loc := GetLogLoc()
 	if loc == "" {
 		t.Error("expected log file to not be empty but it was")
@@ -93,7 +95,8 @@ func TestStartLogMessage(t *testing.T) {
 }
 
 func TestEndLogMessage(t *testing.T) {
-	InitLogger()
+	tempDir := t.TempDir()
+	InitLoggerWithOutputDir(tempDir)
 	loc := GetLogLoc()
 	out, err := output.CaptureOutput(func() {
 		LogEndMessage()
@@ -196,7 +199,8 @@ func TestLogIsCreatedInOutputDir(t *testing.T) {
 }
 func TestLogIsNotCreatedAtBasePathWithOutputDir(t *testing.T) {
 	// First, get the default log location
-	InitLogger()
+	tempDir := t.TempDir()
+	InitLoggerWithOutputDir(tempDir)
 	defaultLogPath := GetLogLoc()
 	if defaultLogPath == "" {
 		t.Fatal("Default log path should not be empty")
@@ -213,7 +217,6 @@ func TestLogIsNotCreatedAtBasePathWithOutputDir(t *testing.T) {
 	}
 
 	// Create a temp directory for the output
-	tempDir := t.TempDir()
 	outputDir := filepath.Join(tempDir, "custom_logs")
 
 	// Create the output directory


### PR DESCRIPTION
Also added some more tests, manually tested with:

- set `--output-file`to a diff location from when `CWD` and checked that the archive includes it 
- didnt set `--output-file` and it runs ok

The only thing that can happen is a empty `ddc.log` is created in the `CWD` when the `init` is run during normal usage - I dont see this as a problem though?