### PR TITLE
added -z and -a flag to root command

### DIFF
--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -820,5 +820,5 @@ func init() {
 	LocalCollectCmd.Flags().StringVar(&ddcYamlLoc, "ddc-yaml", filepath.Join(execLocDir, "ddc.yaml"), "location of ddc.yaml that will be transferred to remote nodes for collection configuration")
 	LocalCollectCmd.Flags().StringVar(&collectionMode, "collect", "light", "type of collection: 'light'- 2 days of logs (no top, jstack or jfr). 'standard' - includes jfr, top, 7 days of logs and 30 days of queries.json logs. 'standard+jstack' - all of 'standard' plus jstack. 'health-check' - all of 'standard' + WLM, KV Store Report, 25,000 Job Profiles")
 	LocalCollectCmd.Flags().IntP(conf.KeyArchiveSizeLimitMB, "z", 256, "maximum size in MB for each archive file before splitting into multiple files")
-	LocalCollectCmd.Flags().Bool(conf.KeyDisableArchiveSplitting, false, "disable splitting archives when they exceed the size limit (when enabled, creates single archive regardless of size)")
+	LocalCollectCmd.Flags().BoolP(conf.KeyDisableArchiveSplitting, "a", false, "disable splitting archives when they exceed the size limit (when enabled, creates single archive regardless of size)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,20 +65,22 @@ var (
 var outputLoc string
 
 var (
-	sudoUser              string
-	namespace             string
-	k8sContext            string
-	disableFreeSpaceCheck bool
-	disableKubeCtl        bool
-	minFreeSpaceGB        uint64
-	disablePrompt         bool
-	detectNamespace       bool
-	collectionMode        string
-	cliAuthToken          string
-	pid                   string
-	transferThreads       int
-	manualPATPrompt       bool
-	noLogDir              bool
+	sudoUser                string
+	namespace               string
+	k8sContext              string
+	disableFreeSpaceCheck   bool
+	disableKubeCtl          bool
+	minFreeSpaceGB          uint64
+	disablePrompt           bool
+	detectNamespace         bool
+	collectionMode          string
+	cliAuthToken            string
+	pid                     string
+	transferThreads         int
+	manualPATPrompt         bool
+	noLogDir                bool
+	archiveSizeLimitMB      int
+	disableArchiveSplitting bool
 )
 
 // var isEmbeddedK8s bool
@@ -552,18 +554,20 @@ func Execute(args []string) error {
 			hook.AddUIStop(stop)
 		}
 		collectionArgs := collection.Args{
-			OutputLoc:             filepath.Clean(outputLoc),
-			DDCfs:                 helpers.NewRealFileSystem(),
-			DremioPAT:             dremioPAT,
-			TransferDir:           transferDir,
-			DDCYamlLoc:            ddcYamlLoc,
-			Enabled:               enabled,
-			Disabled:              disabled,
-			DisableFreeSpaceCheck: disableFreeSpaceCheck,
-			MinFreeSpaceGB:        minFreeSpaceGB,
-			CollectionMode:        collectionMode,
-			TransferThreads:       transferThreads,
-			NoLogDir:              noLogDir,
+			OutputLoc:               filepath.Clean(outputLoc),
+			DDCfs:                   helpers.NewRealFileSystem(),
+			DremioPAT:               dremioPAT,
+			TransferDir:             transferDir,
+			DDCYamlLoc:              ddcYamlLoc,
+			Enabled:                 enabled,
+			Disabled:                disabled,
+			DisableFreeSpaceCheck:   disableFreeSpaceCheck,
+			MinFreeSpaceGB:          minFreeSpaceGB,
+			CollectionMode:          collectionMode,
+			TransferThreads:         transferThreads,
+			NoLogDir:                noLogDir,
+			ArchiveSizeLimitMB:      archiveSizeLimitMB,
+			DisableArchiveSplitting: disableArchiveSplitting,
 		}
 		sshArgs := ssh.Args{
 			SSHKeyLoc:      sshKeyLoc,
@@ -642,6 +646,8 @@ func init() {
 	RootCmd.Flags().Uint64Var(&minFreeSpaceGB, "min-free-space-gb", 0, "min free space needed in GB for the process to run (default 5GB light collect, 25GB for standard and standard+jstack, 40GB for health-check and WAF)")
 	RootCmd.Flags().StringVar(&transferDir, "transfer-dir", fmt.Sprintf("/tmp/ddc-%v", time.Now().Format("20060102150405")), "directory to use for communication between the local-collect command and this one")
 	RootCmd.Flags().StringVar(&outputLoc, "output-file", "diag.tgz", "name and location of diagnostic tarball")
+	RootCmd.Flags().IntVarP(&archiveSizeLimitMB, conf.KeyArchiveSizeLimitMB, "z", 256, "maximum size in MB for each archive file before splitting into multiple files")
+	RootCmd.Flags().BoolVarP(&disableArchiveSplitting, conf.KeyDisableArchiveSplitting, "a", false, "disable splitting archives when they exceed the size limit (when enabled, creates single archive regardless of size)")
 
 	execLoc, err := os.Executable()
 	if err != nil {

--- a/cmd/root/collection/capture.go
+++ b/cmd/root/collection/capture.go
@@ -277,6 +277,15 @@ func StartCapture(c HostCaptureConfiguration, ddcBinaryInfo ddcbinary.BinaryInfo
 	if disableFreeSpaceCheck {
 		localCollectArgs = append(localCollectArgs, fmt.Sprintf("--%v", conf.KeyDisableFreeSpaceCheck))
 	}
+	if c.ArchiveSizeLimitMB > 0 {
+		// we use the short flag to avoid hitting limits on the length of the command line
+		localCollectArgs = append(localCollectArgs, "-z", fmt.Sprintf("%v", c.ArchiveSizeLimitMB))
+	}
+	if c.DisableArchiveSplitting {
+		// we use the short flag to avoid hitting limits on the length of the command line
+		localCollectArgs = append(localCollectArgs, "-a")
+	}
+
 	if c.NoLogDir {
 		localCollectArgs = append(localCollectArgs, "--no-log-dir")
 	}


### PR DESCRIPTION
- -z this allows us to control throttling rates for kubectl cp effectively by controlling chunk size
- -a disables this behavior and returns to the old approach