### PR TITLE
extra logging for file moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.5.3] - 2025-07-03
+
+### Added
+
+* Extra logging
+
 ## [3.5.2] - 2025-07-03
 
 ### Added
@@ -932,6 +938,7 @@ someone has added the PAT which is always available
 
 - able to capture logs, configuration and diagnostic data from Dremio clusters deployed on Kubernetes and on-prem
 
+[3.5.3]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.5.2...v3.5.3
 [3.5.2]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.5.1...v3.5.2
 [3.5.1]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/dremio/dremio-diagnostic-collector/compare/v3.4.1...v3.5.0

--- a/cmd/local/conf/conf.go
+++ b/cmd/local/conf/conf.go
@@ -455,18 +455,17 @@ func ReadConf(hook shutdown.Hook, overrides map[string]string, ddcYamlLoc, colle
 
 			// configure log dir
 			configuredLogDir := GetString(confData, KeyDremioLogDir)
-			fmt.Printf("configured log dir is: %v\ndetected log dir is: %v\n", configuredLogDir, detectedConfig.LogDir)
+			fmt.Printf("ddc.yaml log dir is: %v, detected log dir is: %v\n", configuredLogDir, detectedConfig.LogDir)
 			// see if the configured dir is valid
 			if err := dirs.CheckDirectory(configuredLogDir, containsValidLog); err != nil {
-				msg := fmt.Sprintf("configured log %v is invalid: %v", configuredLogDir, err)
+				msg := fmt.Sprintf("the ddc.yaml configured log directory %v is not usable (%v), therefore we are using autodetected value of %v for log collection", configuredLogDir, err, detectedConfig.LogDir)
 				consoleprint.ErrorPrint(msg)
 				simplelog.Warning(msg)
 			} else {
+				// if the configured directory is valid ALWAYS pick that
+				simplelog.Infof("using ddc.yaml configured log directory for log collection: %v", configuredLogDir)
 				c.dremioLogDir = configuredLogDir
 			}
-			msg := fmt.Sprintf("using log dir '%v'", c.dremioLogDir)
-			simplelog.Info(msg)
-			fmt.Println(msg)
 			if err := dirs.CheckDirectory(c.dremioLogDir, containsValidLog); err != nil {
 				return &CollectConf{}, fmt.Errorf("invalid dremio log dir '%v', set dremio-log-dir in ddc.yaml or if you want to skip log dir collection run --no-log-dir: %w", c.dremioLogDir, err)
 			}
@@ -483,16 +482,14 @@ func ReadConf(hook shutdown.Hook, overrides map[string]string, ddcYamlLoc, colle
 					return errors.New("configuration directory is empty")
 				}
 			}); err != nil {
-				msg := fmt.Sprintf("configured dir %v is invalid: %v", configuredConfDir, err)
+				msg := fmt.Sprintf("the ddc.yaml configured configuration directory %v is not usable (%v), therefore we are using autodetected value of %v for configuration collection", configuredConfDir, err, detectedConfig.ConfDir)
 				fmt.Println(msg)
 				simplelog.Warning(msg)
 			} else {
 				// if the configured directory is valid ALWAYS pick that
+				simplelog.Infof("using ddc.yaml configured configuration directory for configuration collection: %v", configuredConfDir)
 				c.dremioConfDir = configuredConfDir
 			}
-			msg := fmt.Sprintf("using config dir '%v'", c.dremioConfDir)
-			simplelog.Info(msg)
-			fmt.Println(msg)
 			if err := dirs.CheckDirectory(c.dremioConfDir, func(de []fs.DirEntry) error {
 				if len(de) > 0 {
 					return nil

--- a/pkg/dirs/dirs.go
+++ b/pkg/dirs/dirs.go
@@ -16,7 +16,6 @@
 package dirs
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -30,29 +29,29 @@ func CheckDirectory(dirPath string, fileCheck func([]fs.DirEntry) error) error {
 	fileInfo, err := os.Stat(dirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("directory does not exist")
+			return fmt.Errorf("directory %v does not exist", dirPath)
 		}
 		return fmt.Errorf("error checking directory: %w", err)
 	}
 
 	// Check if the path is a directory
 	if !fileInfo.IsDir() {
-		return errors.New("the path is not a directory")
+		return fmt.Errorf("the path %v is not a directory", dirPath)
 	}
 
 	// Read the contents of the directory
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
-		return fmt.Errorf("error reading directory: %w", err)
+		return fmt.Errorf("error reading directory %v: %w", dirPath, err)
 	}
 
 	// Check if the directory is empty
 	if len(files) == 0 {
-		return errors.New("directory is empty")
+		return fmt.Errorf("directory %v is empty", dirPath)
 	}
 
 	if err := fileCheck(files); err != nil {
-		return fmt.Errorf("file check function failed: %w", err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
- to help in debugging we are adding the file copy paths
- we log more detail around which configuration directory is used and which log directory is used as well as more thorough explanations for the reasoning behind the choice made