### PR TITLE
INF-4734: add initial jenkinfiles for ddc build, delete and release jobs

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,106 @@
+# Jenkins Pipeline Configuration
+
+This directory contains Jenkins pipeline definitions for the dremio-diagnostic-collector project.
+
+## Pipelines
+
+- **build.Jenkinsfile** - Main build pipeline that creates a K3s cluster and runs tests
+- **release.Jenkinsfile** - Release pipeline for publishing releases
+- **delete.Jenkinsfile** - Cleanup pipeline
+- **agent.yaml** - Kubernetes pod template for Jenkins agents
+
+## Build Pipeline Configuration
+
+The `build.Jenkinsfile` requires several environment variables to be configured in Jenkins. These can be set via:
+- Jenkins job configuration (Environment Variables)
+- HashiCorp Vault (recommended for sensitive data)
+- Jenkins global properties
+
+### Required Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `GCP_PROJECT_ID` | Google Cloud Project ID | `your-gcp-project` |
+| `GCP_ZONE` | GCP zone for VM instances | `us-west1-b` |
+| `GCP_SERVICE_ACCOUNT` | GCP service account email | `your-sa@developer.gserviceaccount.com` |
+| `GCP_NETWORK_SUBNET` | GCP subnet name | `primary-west` |
+| `GCP_MACHINE_TYPE` | GCE instance machine type | `e2-standard-16` |
+| `GCP_DISK_SIZE` | Boot disk size in GB | `100` |
+| `GCP_DISK_POLICY` | (Optional) Disk resource policy | `projects/PROJECT/regions/REGION/resourcePolicies/POLICY` |
+| `GCP_IMAGE` | GCE boot disk image | `projects/debian-cloud/global/images/debian-12-bookworm-v20240910` |
+
+### Required Vault Secrets
+
+The build pipeline requires Google Cloud service account credentials stored in HashiCorp Vault:
+
+**Path:** `secret/support/private/gcloud-service-account`  
+**Key:** `credentials-file`  
+**Value:** Complete JSON content of the GCP service account key file
+
+### How to Configure
+
+#### Option 1: Using Jenkins Environment Variables
+
+1. Go to your Jenkins job → Configure
+2. Check "Prepare an environment for the run"
+3. Add the environment variables listed above
+
+#### Option 2: Using Vault (Recommended)
+
+Store all sensitive configuration in Vault and update the Jenkinsfile to retrieve them using `withVault` blocks.
+
+Example:
+```groovy
+withVault(vaultSecrets: [[
+    path: 'secret/support/private/gcp-config', 
+    secretValues: [
+        [envVar: 'GCP_PROJECT_ID', vaultKey: 'project-id'],
+        [envVar: 'GCP_SERVICE_ACCOUNT', vaultKey: 'service-account'],
+        // ... other values
+    ]
+]]) {
+    // Your build steps
+}
+```
+
+## Pipeline Stages
+
+The build pipeline consists of the following stages:
+
+1. **Setup** - Install basic dependencies (bash, curl, gcloud SDK)
+2. **Install k3sup** - Download and install k3sup tool for K3s cluster management
+3. **GCloud Auth & SSH Setup** - Authenticate with GCP and generate SSH keys
+4. **Create GCE Instances** - Spin up 4 GCE instances in parallel
+5. **Setup K3s Cluster** - Install K3s master node and join worker nodes
+6. **Install Build Tools** - Download Go and kubectl
+7. **Build** - Execute the actual build via `./script/cibuild`
+
+## Automatic Cleanup
+
+The build pipeline **automatically cleans up** all GCE instances after the build completes, regardless of success or failure. This happens in the `post { always }` section to ensure:
+
+- No VMs are left running (avoiding unnecessary costs)
+- Cleanup happens even if the build fails
+- All 4 instances are deleted in parallel for speed
+
+The cleanup stage will show output like:
+```
+Starting cleanup of GCE instances...
+Deleting k8s-ddc-ci-1-123
+Deleting k8s-ddc-ci-2-123
+Deleting k8s-ddc-ci-3-123
+Deleting k8s-ddc-ci-4-123
+  ✓ Successfully deleted k8s-ddc-ci-1-123
+  ✓ Successfully deleted k8s-ddc-ci-2-123
+  ✓ Successfully deleted k8s-ddc-ci-3-123
+  ✓ Successfully deleted k8s-ddc-ci-4-123
+Deletion complete
+```
+
+## Security Notes
+
+- Never commit GCP credentials, project IDs, or service account emails directly to the repository
+- Use environment variables or Vault for all sensitive configuration
+- Rotate service account keys regularly
+- Use least-privilege service accounts with only necessary permissions
+

--- a/jenkins/agent.yaml
+++ b/jenkins/agent.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - image: us-west1-docker.pkg.dev/dremio-1093/dockerhub/alpine:3.23.2
+      imagePullPolicy: Always
+      name: agent
+      command: ["tail", "-f", "/dev/null"]
+      workingDir: /workspace
+      resources:
+        limits:
+          cpu: 3.5
+          memory: 4G
+        requests:
+          cpu: 3.5
+          memory: 4G
+  serviceAccountName: support-tools-sa
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -7,13 +7,174 @@ pipeline {
             yamlFile 'jenkins/agent.yaml'
         }
     }
-    options {
-        timeout(time: 20, unit: 'MINUTES')
+
+    environment {
+        // Set PATH to include our custom bin directories
+        PATH = "${env.PATH}:${env.HOME}/go/bin:${env.HOME}/bin"
+
+        // GCP Configuration - these should be set in Jenkins configuration or Vault
+        GCP_PROJECT_ID = "${env.GCP_PROJECT_ID ?: 'your-gcp-project'}"
+        GCP_ZONE = "${env.GCP_ZONE ?: 'us-west1-b'}"
+        GCP_SERVICE_ACCOUNT = "${env.GCP_SERVICE_ACCOUNT ?: 'your-service-account@developer.gserviceaccount.com'}"
+        GCP_NETWORK_SUBNET = "${env.GCP_NETWORK_SUBNET ?: 'primary-west'}"
+        GCP_MACHINE_TYPE = "${env.GCP_MACHINE_TYPE ?: 'e2-standard-16'}"
+        GCP_DISK_SIZE = "${env.GCP_DISK_SIZE ?: '100'}"
+        GCP_DISK_POLICY = "${env.GCP_DISK_POLICY ?: ''}"
+        GCP_IMAGE = "${env.GCP_IMAGE ?: 'projects/debian-cloud/global/images/debian-12-bookworm-v20240910'}"
+
+        // K3sup version
+        K3SUP_VERSION = "0.13.9"
+
+        // Go and kubectl versions
+        GO_VERSION = "1.24.3"
+        KUBECTL_VERSION = "v1.32.0"
     }
+
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
     stages {
         stage('Setup') {
             steps {
                 sh 'apk add bash curl'
+            }
+        }
+
+        stage('Install k3sup') {
+            steps {
+                sh '''#!/bin/bash
+                    curl -O -L https://github.com/alexellis/k3sup/releases/download/${K3SUP_VERSION}/k3sup
+                    chmod +x k3sup
+                    mkdir -p $HOME/bin
+                    mv k3sup $HOME/bin/
+                '''
+            }
+        }
+
+        stage('GCloud Auth & SSH Setup') {
+            steps {
+                withVault(vaultSecrets: [[
+                    path: 'secret/support/private/gcloud-service-account',
+                    secretValues: [
+                        [envVar: 'GOOGLE_APPLICATION_CREDENTIALS_JSON', vaultKey: 'credentials-file'],
+                    ]
+                ]]) {
+                    sh '''#!/bin/bash
+                        # Write the credentials to a temporary file
+                        echo "${GOOGLE_APPLICATION_CREDENTIALS_JSON}" > /tmp/gcloud-key.json
+
+                        gcloud auth activate-service-account --key-file /tmp/gcloud-key.json
+                        ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519 -q -P ""
+
+                        # Clean up the temporary file
+                        rm -f /tmp/gcloud-key.json
+                    '''
+                }
+            }
+        }
+
+        stage('Create GCE Instances') {
+            steps {
+                sh '''#!/bin/bash
+                    # Function to find and read SSH public key
+                    get_ssh_public_key() {
+                        local ssh_dir="$HOME/.ssh"
+                        local public_key=""
+
+                        # Look for common SSH public key files in order of preference
+                        for key_file in "id_ed25519.pub" "id_rsa.pub" "id_ecdsa.pub" "id_dsa.pub"; do
+                            if [ -f "$ssh_dir/$key_file" ]; then
+                                public_key=$(cat "$ssh_dir/$key_file" | tr -d '\\n\\r')
+                                echo "Found SSH public key: $ssh_dir/$key_file" >&2
+                                break
+                            fi
+                        done
+
+                        if [ -z "$public_key" ]; then
+                            echo "Error: No SSH public key found in $ssh_dir" >&2
+                            echo "Please ensure you have one of the following files:" >&2
+                            echo "  - $ssh_dir/id_ed25519.pub" >&2
+                            echo "  - $ssh_dir/id_rsa.pub" >&2
+                            echo "  - $ssh_dir/id_ecdsa.pub" >&2
+                            echo "  - $ssh_dir/id_dsa.pub" >&2
+                            exit 1
+                        fi
+
+                        echo "$public_key"
+                    }
+
+                    SSH_PUBLIC_KEY="$(get_ssh_public_key)"
+
+                    # Build disk policy parameter if set
+                    DISK_POLICY_PARAM=""
+                    if [ -n "${GCP_DISK_POLICY}" ]; then
+                        DISK_POLICY_PARAM="disk-resource-policy=${GCP_DISK_POLICY},"
+                    fi
+
+                    for n in {1..4}; do
+                        node_name=k8s-ddc-ci-$n-$BUILD_NUMBER
+                        gcloud compute instances create $node_name \\
+                            --project=${GCP_PROJECT_ID} \\
+                            --zone=${GCP_ZONE} \\
+                            --machine-type=${GCP_MACHINE_TYPE} \\
+                            --network-interface=network-tier=PREMIUM,stack-type=IPV4_ONLY,subnet=${GCP_NETWORK_SUBNET} \\
+                            --maintenance-policy=MIGRATE \\
+                            --provisioning-model=STANDARD \\
+                            --metadata="ssh-keys=jenkins:${SSH_PUBLIC_KEY}" \\
+                            --service-account=${GCP_SERVICE_ACCOUNT} \\
+                            --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append \\
+                            --create-disk=auto-delete=yes,boot=yes,device-name=$node_name,${DISK_POLICY_PARAM}image=${GCP_IMAGE},mode=rw,size=${GCP_DISK_SIZE},type=pd-balanced \\
+                            --no-shielded-secure-boot \\
+                            --shielded-vtpm \\
+                            --shielded-integrity-monitoring \\
+                            --labels=goog-ec-src=vm_add-gcloud \\
+                            --reservation-affinity=any &
+                    done
+                    wait < <( jobs -p )
+                    sleep 60
+                '''
+            }
+        }
+
+        stage('Setup K3s Cluster') {
+            steps {
+                sh '''#!/bin/bash
+                    for n in {1..4}; do
+                        node_name=k8s-ddc-ci-$n-$BUILD_NUMBER
+                        if [ "$n" -eq 1 ]; then
+                            MASTER_IP=$(gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
+                            k3sup install --ip $MASTER_IP --user jenkins --ssh-key $HOME/.ssh/id_ed25519
+                        else
+                            IP=$(gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
+                            k3sup join --ip $IP --server-ip $MASTER_IP --user jenkins --ssh-key $HOME/.ssh/id_ed25519
+                        fi
+                    done
+
+                    mkdir -p $HOME/.kube
+                    mv kubeconfig $HOME/.kube/config
+                '''
+            }
+        }
+
+        stage('Install Build Tools') {
+            steps {
+                sh '''#!/bin/bash
+                    wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
+                    tar -C ../ -xzf go${GO_VERSION}.linux-amd64.tar.gz
+                    curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+                    chmod +x kubectl
+                    mv kubectl $HOME/bin
+                '''
+            }
+        }
+
+        stage('Build') {
+            environment {
+                KUBECONFIG = "${env.HOME}/.kube/config"
+            }
+            steps {
+                sh './script/cibuild'
             }
         }
     }

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
         stage('Setup') {
             steps {
                 sh '''
-                    apk add bash curl python3 py3-pip
+                    apk add bash curl python3 py3-pip openssh-client
 
                     # Install gcloud SDK
                     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-458.0.1-linux-x86_64.tar.gz

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -20,11 +20,6 @@ pipeline {
             description: 'GCP Zone for VM instances'
         )
         string(
-            name: 'GCP_SERVICE_ACCOUNT',
-            defaultValue: 'your-service-account@developer.gserviceaccount.com',
-            description: 'GCP Service Account email'
-        )
-        string(
             name: 'GCP_NETWORK_SUBNET',
             defaultValue: 'primary-west',
             description: 'GCP Network Subnet name'
@@ -60,7 +55,6 @@ pipeline {
         // GCP Configuration - use parameters if provided, otherwise fall back to env vars
         GCP_PROJECT_ID = "${params.GCP_PROJECT_ID}"
         GCP_ZONE = "${params.GCP_ZONE}"
-        GCP_SERVICE_ACCOUNT = "${params.GCP_SERVICE_ACCOUNT}"
         GCP_NETWORK_SUBNET = "${params.GCP_NETWORK_SUBNET}"
         GCP_MACHINE_TYPE = "${params.GCP_MACHINE_TYPE}"
         GCP_DISK_SIZE = "${params.GCP_DISK_SIZE}"
@@ -157,7 +151,6 @@ pipeline {
                             --maintenance-policy=MIGRATE \\
                             --provisioning-model=STANDARD \\
                             --metadata="ssh-keys=jenkins:${SSH_PUBLIC_KEY}" \\
-                            --service-account=${GCP_SERVICE_ACCOUNT} \\
                             --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append \\
                             --create-disk=auto-delete=yes,boot=yes,device-name=$node_name,${DISK_POLICY_PARAM}image=${GCP_IMAGE},mode=rw,size=${GCP_DISK_SIZE},type=pd-balanced \\
                             --no-shielded-secure-boot \\

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+    agent {
+        kubernetes {
+            agentInjection true
+            defaultContainer 'agent'
+            cloud 'kubernetes'
+            yamlFile 'jenkins/agent.yaml'
+        }
+    }
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                sh 'apk add bash curl'
+            }
+        }
+    }
+}

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -151,7 +151,6 @@ pipeline {
                             --maintenance-policy=MIGRATE \\
                             --provisioning-model=STANDARD \\
                             --metadata="ssh-keys=jenkins:${SSH_PUBLIC_KEY}" \\
-                            --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append \\
                             --create-disk=auto-delete=yes,boot=yes,device-name=$node_name,${DISK_POLICY_PARAM}image=${GCP_IMAGE},mode=rw,size=${GCP_DISK_SIZE},type=pd-balanced \\
                             --no-shielded-secure-boot \\
                             --shielded-vtpm \\

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
                     ./google-cloud-sdk/install.sh --quiet --path-update=false
 
                     # Verify gcloud is installed
-                    gcloud version
+                    ./google-cloud-sdk/bin/gcloud version
 
                     # Generate SSH key for VM access
                     ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519 -q -P ""
@@ -149,7 +149,7 @@ pipeline {
 
                     for n in {1..4}; do
                         node_name=k8s-ddc-ci-$n-$BUILD_NUMBER
-                        gcloud compute instances create $node_name \\
+                        ./google-cloud-sdk/bin/gcloud compute instances create $node_name \\
                             --project=${GCP_PROJECT_ID} \\
                             --zone=${GCP_ZONE} \\
                             --machine-type=${GCP_MACHINE_TYPE} \\
@@ -178,10 +178,10 @@ pipeline {
                     for n in {1..4}; do
                         node_name=k8s-ddc-ci-$n-$BUILD_NUMBER
                         if [ "$n" -eq 1 ]; then
-                            MASTER_IP=$(gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
+                            MASTER_IP=$(./google-cloud-sdk/bin/gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
                             $HOME/bin/k3sup install --ip $MASTER_IP --user jenkins --ssh-key $HOME/.ssh/id_ed25519
                         else
-                            IP=$(gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
+                            IP=$(./google-cloud-sdk/bin/gcloud compute instances describe $node_name --zone=${GCP_ZONE} --format='get(networkInterfaces[0].networkIP)')
                             $HOME/bin/k3sup join --ip $IP --server-ip $MASTER_IP --user jenkins --ssh-key $HOME/.ssh/id_ed25519
                         fi
                     done
@@ -228,7 +228,7 @@ pipeline {
                             echo "Deleting $node_name"
                             # Run deletion in background and capture results
                             (
-                                if gcloud compute instances delete "$node_name" \\
+                                if ./google-cloud-sdk/bin/gcloud compute instances delete "$node_name" \\
                                     --project=${GCP_PROJECT_ID} \\
                                     --zone=${GCP_ZONE} \\
                                     --quiet 2>/dev/null; then

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
         }
         stage('Create GCE Instances') {
             steps {
-                sh '''
+                sh '''#!/bin/bash
                     # Function to find and read SSH public key
                     get_ssh_public_key() {
                         local ssh_dir="$HOME/.ssh"
@@ -174,7 +174,7 @@ pipeline {
 
         stage('Setup K3s Cluster') {
             steps {
-                sh '''
+                sh '''#!/bin/bash
                     for n in {1..4}; do
                         node_name=k8s-ddc-ci-$n-$BUILD_NUMBER
                         if [ "$n" -eq 1 ]; then
@@ -220,7 +220,7 @@ pipeline {
                 // Cleanup: Delete GCE instances if CLEANUP_INSTANCES is true
                 if (params.CLEANUP_INSTANCES == 'true') {
                     echo "Cleanup enabled - deleting GCE instances..."
-                    sh '''
+                    sh '''#!/bin/bash
                         echo "Starting cleanup of GCE instances..."
 
                         for n in {1..4}; do

--- a/jenkins/delete.Jenkinsfile
+++ b/jenkins/delete.Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+    agent {
+        kubernetes {
+            agentInjection true
+            defaultContainer 'agent'
+            cloud 'kubernetes'
+            yamlFile 'jenkins/agent.yaml'
+        }
+    }
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                sh 'apk add bash curl'
+            }
+        }
+    }
+}

--- a/jenkins/release.Jenkinsfile
+++ b/jenkins/release.Jenkinsfile
@@ -16,5 +16,17 @@ pipeline {
                 sh 'apk add bash curl'
             }
         }
+        stage('Release) {
+            steps {
+                withVault(vaultSecrets: [[
+                    path: 'secret/support/private/ddc_gh_pat', 
+                    secretValues: [
+                        [envVar: 'GITHUB_RELEASE_TOKEN', vaultKey: 'ddc-gh-pat'],
+                    ]
+                ]]) {
+                    echo "Can use secret $GITHUB_RELEASE_TOKEN"
+                }
+            }
+        }
     }
 }

--- a/jenkins/release.Jenkinsfile
+++ b/jenkins/release.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 sh 'apk add bash curl'
             }
         }
-        stage('Release) {
+        stage('Release') {
             steps {
                 withVault(vaultSecrets: [[
                     path: 'secret/support/private/ddc_gh_pat', 

--- a/jenkins/release.Jenkinsfile
+++ b/jenkins/release.Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+    agent {
+        kubernetes {
+            agentInjection true
+            defaultContainer 'agent'
+            cloud 'kubernetes'
+            yamlFile 'jenkins/agent.yaml'
+        }
+    }
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                sh 'apk add bash curl'
+            }
+        }
+    }
+}

--- a/jenkins/release.Jenkinsfile
+++ b/jenkins/release.Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         stage('Release') {
             steps {
                 withVault(vaultSecrets: [[
-                    path: 'secret/support/private/ddc_gh_pat', 
+                    path: 'secret/support/private/ddc-gh-pat', 
                     secretValues: [
                         [envVar: 'GITHUB_RELEASE_TOKEN', vaultKey: 'ddc-gh-pat'],
                     ]


### PR DESCRIPTION
Add Jenkinsfiles for the ddc jobs to be migrated to the new jenkins server 

https://jenkins.drem.io/job/dremio-diagnostic-collector-release
https://jenkins.drem.io/job/dremio-diagnostic-collector
https://jenkins.drem.io/job/dremio-diagnostic-collector-delete

Use service account created in https://github.com/dremio/infra/pull/705 (needed for dremio-diagnostic-collector)
Fetch from vault https://vault.drem.io/ui/vault/secrets/secret/kv/support%2Fprivate%2Fddc-gh-pat/details?version=1  token to create github release