### PR TITLE
Make K8s --namespace optional, default to "default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.1] - 2026-06-16
+
+- `--namespace` is now optional for the K8s transport and defaults to `default`. Previously `ddc collect k8s standard|diagnosis` errored with "--namespace is required" when the flag was omitted.
+
 ## [4.0.0] - 2026-06-10
 
 - Documentation accuracy fixes (README, FAQ): corrected JVM tool opt-in wording, added local/local-k8s examples to help text.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -782,7 +782,8 @@ func Execute(args []string) error {
 				return fmt.Errorf("--coordinator is required for SSH transport. Example: ddc collect ssh standard --coordinator 10.0.0.1 --ssh-user myuser --ssh-key ~/.ssh/id_rsa")
 			}
 			if transportFromCmd == "k8s" && namespace == "" {
-				return fmt.Errorf("--namespace is required for K8s transport. Example: ddc collect k8s standard --namespace mynamespace")
+				// --namespace is optional; default to the "default" namespace when omitted.
+				namespace = "default"
 			}
 			// local transport is zero-config — no required flags
 		}
@@ -1330,7 +1331,7 @@ func init() {
 	SSHCmd.PersistentFlags().BoolVar(&sshStrictHostKeys, "ssh-strict-host-keys", false, "enable strict host key checking (default: false for backward compatibility)")
 
 	// ── K8s transport flags — on K8sCmd.PersistentFlags() ──
-	K8sCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "namespace to use for kubernetes pods")
+	K8sCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "namespace to use for kubernetes pods (default: default)")
 	K8sCmd.PersistentFlags().StringVarP(&k8sContext, "context", "x", "", "context to use for kubernetes pods")
 	K8sCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "path to kubeconfig file (overrides $KUBECONFIG and ~/.kube/config)")
 	K8sCmd.PersistentFlags().StringVar(&detectLabelSelector, "detect-label-selector", "role=dremio-cluster-pod", "label selector used to identify Dremio coordinator/executor pods for file streaming; follows kubernetes label syntax (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -223,12 +223,16 @@ func TestDiagnosisSubcommandSetsMode(t *testing.T) {
 	defer func() { collectionMode = oldMode }()
 	collectionMode = ""
 
-	err := Execute([]string{"ddc", "collect", "k8s", "diagnosis"})
+	// Use the SSH transport here: it short-circuits on the "--coordinator is
+	// required" validation, letting us verify the diagnosis subcommand sets the
+	// mode without falling through into real K8s collection. (K8s no longer
+	// errors on a missing --namespace — it defaults to "default".)
+	err := Execute([]string{"ddc", "collect", "ssh", "diagnosis"})
 	if collectionMode != collects.DiagnosisCollection {
-		t.Errorf("expected collectionMode=%q after 'collect k8s diagnosis', got %q", collects.DiagnosisCollection, collectionMode)
+		t.Errorf("expected collectionMode=%q after 'collect ssh diagnosis', got %q", collects.DiagnosisCollection, collectionMode)
 	}
-	if err == nil || !strings.Contains(err.Error(), "--namespace is required") {
-		t.Errorf("expected K8s transport validation error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "--coordinator is required") {
+		t.Errorf("expected SSH transport validation error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Previously `ddc collect k8s standard|diagnosis` errored with "--namespace is required" when the flag was omitted. Now an empty --namespace defaults to the "default" namespace in non-interactive K8s runs. The flag's registered default stays empty so the interactive-TUI sentinel (namespace != "") is preserved, and the local-k8s transport is unaffected (it auto-detects the namespace from the pod service account).

Repoints TestDiagnosisSubcommandSetsMode to the ssh transport so it still verifies diagnosis mode-setting without falling through into real K8s collection.